### PR TITLE
Add gluon-alfred and gluon-alfred-ffmap

### DIFF
--- a/gluon/gluon-alfred-ffmap/Makefile
+++ b/gluon/gluon-alfred-ffmap/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-alfred-ffmap
+PKG_VERSION:=0.1
+PKG_RELEASE:=1.$(GLUON_CONFIG_VERSION)
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-alfred-ffmap
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+gluon-alfred +gluon-location
+  TITLE:=Distribute data for ffmap via alfred
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-alfred-ffmap/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-alfred-ffmap))

--- a/gluon/gluon-alfred-ffmap/files/etc/alfred/ffmap.sh
+++ b/gluon/gluon-alfred-ffmap/files/etc/alfred/ffmap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [ -f /lib/functions/jshn.sh ]; then
+	. /lib/functions/jshn.sh
+elif [ -f /usr/share/libubox/jshn.sh ]; then
+	. /usr/share/libubox/jshn.sh
+else
+	echo "Error: jshn.sh not found!"
+	exit 1
+fi
+
+[ -z "$ALFRED_DATA_TYPE" ] && ALFRED_DATA_TYPE=158
+
+set -e
+
+json_init
+json_add_string "name" "$(uci get 'system.@system[0].hostname')"
+if [ "$(uci get 'system.@system[0].share_location')" = 1 ]; then
+	json_add_string "gps" "$(uci get 'system.@system[0].latitude') $(uci get 'system.@system[0].longitude')"
+fi 
+json_dump | tr -d '\n' | alfred -s "$ALFRED_DATA_TYPE"

--- a/gluon/gluon-alfred/Makefile
+++ b/gluon/gluon-alfred/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-alfred
+PKG_VERSION:=0.1
+PKG_RELEASE:=1.$(GLUON_CONFIG_VERSION)
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-alfred
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+alfred +gluon-cron
+  TITLE:=Configure alfred
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-alfred/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-alfred))

--- a/gluon/gluon-alfred/files/lib/gluon/upgrade/alfred/invariant/010-enable-alfred
+++ b/gluon/gluon-alfred/files/lib/gluon/upgrade/alfred/invariant/010-enable-alfred
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+uci set alfred.alfred.interface=br-client
+uci set alfred.alfred.mode=slave
+uci delete alfred.alfred.disabled


### PR DESCRIPTION
gluon-alfred simply configures the alfred package from the routing feed to work with the gluon network setup.
gluon-alfred-ffmap sends the hostname and gps coordinates via alfred, so they can be picked up by some host that wants to draw the ffmap (using for example https://github.com/tcatm/ffmap-backend)

Maybe gluon-alfred-ffmap can be extended to send even more information like IP addresses or traffic statistics.
