### PR TITLE
gluon-autoupdater: get random number from urandom

### DIFF
--- a/gluon/gluon-autoupdater/files/usr/sbin/autoupdater
+++ b/gluon/gluon-autoupdater/files/usr/sbin/autoupdater
@@ -10,7 +10,9 @@ BRANCH=$(uci get autoupdater.settings.branch)
 PROBABILITY=$(uci get autoupdater.${BRANCH}.probability)
 
 if test "a$1" != "a-f"; then
-  echo | awk "END{srand();exit rand() > $PROBABILITY}"
+  # get one random byte from /dev/urandom, convert it to decimal and check
+  # against update_probability*255
+  hexdump -n1 -e '/1 "%d"' /dev/urandom | awk "{exit \$1 > $PROBABILITY * 255}"
   if test $? -ne 0; then
     echo "No autoupdate this time. Use -f to override"
     exit 0


### PR DESCRIPTION
The approach with awk's rand() wasn't really random between across
devices: When srand() was called without arguments, time() was used as
seed, which of course is the same on all devices when the script is
called via cron at HH:00:00.

This patch instead uses /dev/urandom as source of random (we don't need
cryptographically strong random numbers, so urandom is just fine) but
still uses awk for the comparison as busybox's ash cannot deal with
floats in $(())
