### PR TITLE
gluon-autoupdater: enable list of mirrors for manifest and firmware.

### DIFF
--- a/gluon/gluon-autoupdater/files/usr/sbin/autoupdater
+++ b/gluon/gluon-autoupdater/files/usr/sbin/autoupdater
@@ -19,7 +19,7 @@ if test "a$1" != "a-f"; then
   fi
 fi
 
-BASE=$(uci get autoupdater.${BRANCH}.url)
+MIRRORS=$(uci get autoupdater.${BRANCH}.mirror)
 PUBKEYS=$(uci get autoupdater.${BRANCH}.pubkey)
 GOOD_SIGNATURES=$(uci get autoupdater.${BRANCH}.good_signatures)
 
@@ -166,4 +166,13 @@ fi
 
 my_version="$(cat "$VERSION_FILE")"
 
-autoupdate $BASE && exit 0
+for mirror in $MIRRORS; do
+
+  autoupdate $mirror && exit 0
+
+  unset fw_version
+  unset fw_md5
+  unset fw_file
+
+done
+

--- a/gluon/gluon-autoupdater/invariant.pl
+++ b/gluon/gluon-autoupdater/invariant.pl
@@ -28,8 +28,12 @@ delete autoupdater.$name
 set autoupdater.$name=branch
 END
 
-  for (qw(url probability good_signatures)) {
+  for (qw(probability good_signatures)) {
     print "set autoupdater.$name.$_=$branch->{$_}\n";
+  }
+
+  for (@{$branch->{mirrors}}) {
+    print "add_list autoupdater.$name.mirror=$_\n";
   }
 
   for (@{$branch->{pubkeys}}) {


### PR DESCRIPTION
Instead of a single url this patch allows to have a list of urls. So in case
of network instability a router can still reach local mesh-cloud server to pull
a update from. In this stage the autoupdater simply tries every mirror until
one passes all tests.
