### PR TITLE
gluon-config-mode: correct hostname on reboot.html

### DIFF
--- a/gluon/gluon-config-mode/files/usr/lib/lua/luci/controller/gluon-config-mode/index.lua
+++ b/gluon/gluon-config-mode/files/usr/lib/lua/luci/controller/gluon-config-mode/index.lua
@@ -58,8 +58,11 @@ function action_reboot()
   uci:save("gluon-config-mode")
   uci:commit("gluon-config-mode")
 
+  hostname = uci:get_first("system", "system", "hostname")
+
   if nixio.fork() ~= 0 then
-    luci.template.render("gluon-config-mode/reboot", {pubkey=pubkey})
+    luci.template.render("gluon-config-mode/reboot",
+      {pubkey=pubkey, hostname=hostname})
   else
     debug.setfenv(io.stdout, debug.getfenv(io.open '/dev/null'))
     io.stdout:close()

--- a/gluon/gluon-config-mode/generate/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
+++ b/gluon/gluon-config-mode/generate/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
@@ -15,7 +15,7 @@ $Id$
 
 <html>
   <head>
-    <title><%=luci.sys.hostname()%> - <% if title then %><%=title%><% else %><%:Rebooting...%><% end %></title>
+    <title><%=hostname%> - <% if title then %><%=title%><% else %><%:Rebooting...%><% end %></title>
     <link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css" />
   </head>
   <body>
@@ -28,7 +28,7 @@ $Id$
             @config_mode.msg_pubkey@
           </p>
           <div class="the-key">
-            # <%=luci.sys.hostname()%>
+            # <%=hostname%>
             <br/>
             <%=pubkey%>
           </div>


### PR DESCRIPTION
Display the correct hostname on the final page of configmode.
Previously, this page used to simply call luci.sys.hostname() which
would return the current hostname. However, when the configmode changes
the hostname luci.sys.hostname() will not reflect this. This patch
fetches the hostname directly from the UCI system config.

This adds a variable called 'hostname' which may be used in site.conf at
config_mode.msg_reboot and .msg_pubkey.
