### PR TITLE
gluon-core: force kernel panic on out of memory

### DIFF
--- a/gluon/gluon-core/files/lib/gluon/functions/sysctl.sh
+++ b/gluon/gluon-core/files/lib/gluon/functions/sysctl.sh
@@ -1,0 +1,4 @@
+sysctl_set() {
+  sed -i "/^${1//./\.}=/d" /etc/sysctl.conf 
+  echo "${1}=$2" >> /etc/sysctl.conf
+}

--- a/gluon/gluon-core/files/lib/gluon/upgrade/core/invariant/012-reboot-on-oom
+++ b/gluon/gluon-core/files/lib/gluon/upgrade/core/invariant/012-reboot-on-oom
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. /lib/gluon/functions/sysctl.sh
+
+sysctl_set vm.panic_on_oom 1


### PR DESCRIPTION
In combination with kernel.panic the node will reboot if out of memory.
