### PR TITLE
gluon-autoupdater: update manifest.sample

### DIFF
--- a/gluon/gluon-autoupdater/manifest.sample
+++ b/gluon/gluon-autoupdater/manifest.sample
@@ -1,6 +1,8 @@
 BRANCH=stable
 
-# model               ver md5sum                           filename
-tp-link-tl-wdr4300-v1 0.4 73e0788596850798d8e02a9ac577d201 sysupgrade-wdr4300.bin
+# model               ver sha512sum                                                                                                                        filename
+tp-link-tl-wdr4300-v1 0.4 c300c2b80a8863506cf3b19359873c596d87af3183c4826462dfb5aa69bec7ce65e3db23a9f6f779fd0f3cc50db5d57070c2b62942abf4fb0e08ae4cb48191a0 gluon-0.4-tp-link-tl-wdr4300-v1-sysupgrade.bin
+
+# after three dashes follow the ecdsa signatures of everything above the dashes
 ---
 49030b7b394e0bd204e0faf17f2d2b2756b503c9d682b135deea42b34a09010bff139cbf7513be3f9f8aae126b7f6ff3a7bfe862a798eae9b005d75abbba770a


### PR DESCRIPTION
We use SHA512 now. Also, added a comment explaining the ECDSA signatures.
