### PR TITLE
Support for custom fastd config files in /etc/fastd/

### DIFF
--- a/net/fastd/Config.in
+++ b/net/fastd/Config.in
@@ -62,21 +62,21 @@ config FASTD_ENABLE_MAC_GHASH
 config FASTD_WITH_CMDLINE_USER
 	bool "Include support for setting user/group related options on the command line"
 	depends on PACKAGE_fastd
-	default n
+	default y
 
 config FASTD_WITH_CMDLINE_LOGGING
 	bool "Include support for setting logging related options on the command line"
 	depends on PACKAGE_fastd
-	default n
+	default y
 
 config FASTD_WITH_CMDLINE_OPERATION
 	bool "Include support for setting options related to the VPN operation (like mode, interface, encryption method) on the command line"
 	depends on PACKAGE_fastd
-	default n
+	default y
 
 config FASTD_WITH_CMDLINE_COMMANDS
 	bool "Include support for setting handler scripts (e.g. --on-up) on the command line"
 	depends on PACKAGE_fastd
-	default n
+	default y
 
 endmenu

--- a/net/fastd/files/fastd.init
+++ b/net/fastd/files/fastd.init
@@ -110,6 +110,13 @@ append_options() {
 	done
 }
 
+append_custom_configs() {
+	local fastd_configs=/etc/fastd/
+	for f in $(ls $fastd_configs)
+	do
+		eval echo 'include \"$fastd_configs$f\"\;'
+	done
+}
 
 generate_config_secret() {
 	echo "secret $(escape_string "$1");"
@@ -305,7 +312,7 @@ start_instance() {
 		chown "$user" "$SERVICE_PID_FILE"
 	fi
 
-	(generate_config_secret "$secret"; generate_config "$s") | service_start "$FASTD_COMMAND" --config - --daemon --pid-file "$SERVICE_PID_FILE"
+	(generate_config_secret "$secret"; generate_config "$s"; append_custom_configs) | service_start "$FASTD_COMMAND" --config - --daemon --pid-file "$SERVICE_PID_FILE"
 
 	if ! ifconfig "$interface" >/dev/null 2>&1; then
 		error "$s: startup failed"


### PR DESCRIPTION
For our local freifunk we need an option to add configuration options to fastd. With these changes fastd will look in /etc/fastd/ (which is initially empty) for files and add them with 'include'. Other packages can add those files and insert options like 'on pre-up' to fastd.

To allow any possible option fastd is compiled with all FASTD_WITH_CMDLINE_\* enabled.
