### PR TITLE
gluon-config-mode

### DIFF
--- a/gluon/gluon-config-mode/generate/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
+++ b/gluon/gluon-config-mode/generate/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
@@ -30,7 +30,7 @@ $Id$
           <div class="the-key">
             # <%=hostname%>
             <br/>
-            <%=pubkey%>
+            key "<%=pubkey%>";
           </div>
         </fieldset>
         <% end %>


### PR DESCRIPTION
display vpnkey in fastd format for copy paste friendly mailing.
