### PR TITLE
gluon-batman-on-wan + gluon-luci-portconfig

### DIFF
--- a/gluon/gluon-luci-portconfig/Makefile
+++ b/gluon/gluon-luci-portconfig/Makefile
@@ -1,0 +1,39 @@
+# Copyright (C) 2013 Nils Schneider <nils at nilsschneider.net>
+# This is free software, licensed under the Apache 2.0 license.
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-luci-portconfig
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-luci-portconfig
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Luci module for advanced ethernet port configuration
+  DEPENDS:=+gluon-luci-admin +gluon-mesh-batman-adv
+endef
+
+define Package/gluon-luci-portconfig/description
+	Luci module for advanced ethernet port configuration
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-luci-portconfig/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-luci-portconfig))

--- a/gluon/gluon-luci-portconfig/files/usr/lib/lua/luci/controller/admin/portconfig.lua
+++ b/gluon/gluon-luci-portconfig/files/usr/lib/lua/luci/controller/admin/portconfig.lua
@@ -1,0 +1,20 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2013 Nils Schneider <nils@nilsschneider.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+module("luci.controller.admin.portconfig", package.seeall)
+
+function index()
+        entry({"admin", "portconfig"}, cbi("admin/portconfig"), _("Schnittstellen"), 20)
+end
+

--- a/gluon/gluon-luci-portconfig/files/usr/lib/lua/luci/model/cbi/admin/portconfig.lua
+++ b/gluon/gluon-luci-portconfig/files/usr/lib/lua/luci/model/cbi/admin/portconfig.lua
@@ -1,0 +1,38 @@
+--[[
+LuCI - Lua Configuration Interface
+
+Copyright 2014 Nils Schneider <nils@nilsschneider.net>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+$Id$
+]]--
+
+local uci = luci.model.uci.cursor()
+
+f = SimpleForm("portconfig")
+f.template = "admin/expertmode"
+f.submit = "Speichern"
+f.reset = "Zurücksetzen"
+
+s = f:section(SimpleSection, nil, nil)
+
+o = s:option(Flag, "mesh_wan", "Mesh auf dem WAN-Port aktivieren")
+o.default = uci:get_bool("network", "mesh_wan", "auto") and o.enabled or o.disabled
+o.rmempty = false
+
+function f.handle(self, state, data)
+  if state == FORM_VALID then
+    uci:set("network", "mesh_wan", "auto", data.mesh_wan)
+    uci:save("network")
+    uci:commit("network")
+  end
+
+  return true
+end
+
+return f

--- a/gluon/gluon-mesh-batman-adv/files/lib/gluon/upgrade/mesh-batman-adv/invariant/030-mesh-on-wan
+++ b/gluon/gluon-mesh-batman-adv/files/lib/gluon/upgrade/mesh-batman-adv/invariant/030-mesh-on-wan
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require 'luci.model.uci'
+
+local c = uci.cursor()
+
+if not c:get('network', 'mesh_wan') then
+  c:section('network', 'interface', 'mesh_wan',
+            { ifname = 'br-wan'
+            , proto  = 'batadv'
+            , mesh   = 'bat0'
+            , auto   = site.mesh_on_wan and 1 or 0
+            })
+end
+
+c:save('network')
+c:commit('network')


### PR DESCRIPTION
This adds an interface named wan_mesh which will be part of bat0 so nodes can be connected over batman-adv. The default option must be set using the site.conf option batman_on_wan to either 0 (disabled) or 1 (enabled).

In addition, gluon-luci-portconfig is included offering users to change the setting from expertmode.
