### PR TITLE
Allow sysconfig variable to be used on reboot page

### DIFF
--- a/gluon/gluon-config-mode/files/usr/lib/lua/luci/controller/gluon-config-mode/index.lua
+++ b/gluon/gluon-config-mode/files/usr/lib/lua/luci/controller/gluon-config-mode/index.lua
@@ -52,6 +52,7 @@ function action_reboot()
   local pubkey
   local uci = luci.model.uci.cursor()
   local meshvpn_enabled = uci:get("fastd", meshvpn_name, "enabled", "0")
+  local sysconfig = require 'gluon.sysconfig'
   if meshvpn_enabled == "1" then
     pubkey = configmode.get_fastd_pubkey(meshvpn_name)
   end
@@ -64,7 +65,7 @@ function action_reboot()
 
   if nixio.fork() ~= 0 then
     luci.template.render("gluon-config-mode/reboot",
-      {luci=luci, pubkey=pubkey, hostname=hostname, site=site})
+      {luci=luci, pubkey=pubkey, hostname=hostname, site=site, sysconfig=sysconfig})
   else
     debug.setfenv(io.stdout, debug.getfenv(io.open '/dev/null'))
     io.stdout:close()


### PR DESCRIPTION
until now, sysconfig variable can only be used on the wizard page.
this adds the possibility to use it on the reboot page, for example to be used for generating pre-filled signup links.
