### PR TITLE
gluon-radvd: RDNSS on next-node address

### DIFF
--- a/gluon/gluon-radvd/files/lib/gluon/radvd/generate_config
+++ b/gluon/gluon-radvd/files/lib/gluon/radvd/generate_config
@@ -10,5 +10,6 @@ interface br-client
 	AdvDefaultLifetime 0;
 
 	prefix ]] .. site.prefix6 .. [[ {};
+	RDNSS ]] .. site.next_node.ip6 .. [[ {};
 };
 ]])


### PR DESCRIPTION
This enables RDNSS on the next-node address. The node will handle all
DNS requests on behalf of clients and is able to provide basic DNS
service even without a gateway.
