### PR TITLE
gluon-autoupdater: ubiquity-bullet-m also works with picostation

### DIFF
--- a/gluon/gluon-autoupdater/README.md
+++ b/gluon/gluon-autoupdater/README.md
@@ -5,7 +5,7 @@ Ubiquity
 --------
 
 ubiquity-nanostation-m (dual ethernet)
-ubiquity-bullet-m (single ethernet: Bullet M, Nanostation loco M)
+ubiquity-bullet-m (single ethernet: Bullet M, NanoStation Loco M, PicoStation M2/M5)
 
 TP-Link
 -------


### PR DESCRIPTION
My PicoStation M2 works well with the ubiquity-bullet-m firmware.

The OpenWRT wiki also suggests to use the bullet-m image:
http://wiki.openwrt.org/toh/ubiquiti/picostationm2#installing.openwrt.on.picostation
