### PR TITLE
gluon-config-mode: match fastd syntax in key snippet

### DIFF
--- a/gluon/gluon-config-mode/files/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
+++ b/gluon/gluon-config-mode/files/usr/lib/lua/luci/view/gluon-config-mode/reboot.htm
@@ -18,7 +18,7 @@
           <div class="the-key">
             # <%= hostname %>
             <br/>
-            <%= pubkey %>
+            key "<%= pubkey %>";
           </div>
         </fieldset>
         <% end %>


### PR DESCRIPTION
Should make it easier to copy&paste the thing.
