### PR TITLE
gluon-mesh-batman-adv: announce MAC of mesh ifaces

### DIFF
--- a/gluon/gluon-mesh-batman-adv/files/lib/gluon/announce/announce.d/network/mesh_interfaces
+++ b/gluon/gluon-mesh-batman-adv/files/lib/gluon/announce/announce.d/network/mesh_interfaces
@@ -1,0 +1,15 @@
+require 'ubus'
+
+local conn = ubus.connect()
+local list = util.exec('batctl if')
+
+local interfaces = {}
+for _, line in ipairs(util.split(list)) do
+	local ifname = line:match('^(.-):')
+	if ifname ~= nil then
+		local status = conn:call("network.device", "status", { name = ifname })
+		table.insert(interfaces, status['macaddr'])
+	end
+end
+
+return interfaces


### PR DESCRIPTION
This will make a node announce all MACs of its interfaces participating
in the batman-adv mesh. This enables other nodes to associate the
announced object with both the data reported by batadv-vis as well as a
simple list of neighbours as output by `iw dev $IFACE station dump`.
