### PR TITLE
gluon-luci-private-wifi: UI for enabling a private WLAN

### DIFF
--- a/gluon/gluon-luci-privatewifi/Makefile
+++ b/gluon/gluon-luci-privatewifi/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-luci-privatewifi
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-luci-privatewifi
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+gluon-luci-admin
+  TITLE:=UI for activating a private WLAN
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-luci-privatewifi/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-luci-privatewifi))

--- a/gluon/gluon-luci-privatewifi/files/usr/lib/lua/luci/controller/admin/privatewifi.lua
+++ b/gluon/gluon-luci-privatewifi/files/usr/lib/lua/luci/controller/admin/privatewifi.lua
@@ -1,0 +1,5 @@
+module("luci.controller.admin.privatewifi", package.seeall)
+
+function index()
+	entry({"admin", "privatewifi"}, cbi("admin/privatewifi"), "Privates WLAN", 10)
+end

--- a/gluon/gluon-luci-privatewifi/files/usr/lib/lua/luci/model/cbi/admin/privatewifi.lua
+++ b/gluon/gluon-luci-privatewifi/files/usr/lib/lua/luci/model/cbi/admin/privatewifi.lua
@@ -1,0 +1,63 @@
+local f, s, o, ssid
+local uci = luci.model.uci.cursor()
+local config = 'wireless'
+
+-- where to read the configuration from
+local primary_iface = 'wan_radio0'
+local ssid = uci:get(config, primary_iface, "ssid")
+
+f = SimpleForm("wifi", "Privates WLAN")
+f.reset = false
+f.template = "admin/expertmode"
+f.submit = "Fertig"
+
+s = f:section(SimpleSection, nil, [[
+Dein Freifunk-Router kann ebenfalls die Reichweite deines privaten Netzes erweitern.
+Hierfür wird der WAN-Port mit einem seperaten WLAN gebridged.
+Diese Funktionalität ist völlig unabhängig von Freifunk.
+Beachte, dass du nicht gleichzeitig das Meshen über den WAN Port aktiviert haben solltest.
+]])
+
+o = s:option(Flag, "enabled", "Aktiviert")
+o.default = (ssid and not uci:get_bool(config, primary_iface, "disabled")) and o.enabled or o.disabled
+o.rmempty = false
+
+o = s:option(Value, "ssid", "Name (SSID)")
+o.default = ssid
+
+o = s:option(Value, "key", "Schlüssel", "8-63 Zeichen")
+o.datatype = "wpakey"
+o.default = uci:get(config, primary_iface, "key")
+
+function f.handle(self, state, data)
+  if state == FORM_VALID then
+    uci:foreach(config, "wifi-device",
+      function(s)
+        local device = s['.name']
+        local name   = "wan_" .. device
+
+        if data.enabled == '1' then
+          -- set up WAN wifi-iface
+          local t      = uci:get_all(config, name) or {}
+
+          t.device     = device
+          t.network    = "wan"
+          t.mode       = 'ap'
+          t.encryption = 'psk2'
+          t.ssid       = data.ssid
+          t.key        = data.key
+          t.disabled   = "false"
+
+          uci:section(config, "wifi-iface", name, t)
+        else
+          -- disable WAN wifi-iface
+          uci:set(config, name, "disabled", "true")
+        end
+    end)
+
+    uci:save(config)
+    uci:commit(config)
+  end
+end
+
+return f


### PR DESCRIPTION
This pull request contains the package `gluon-luci-private-wifi` for setting up a private WLAN as requested in freifunk-gluon/gluon#122

I tested it by running my device in config mode and copying the files with scp into to target folder:
`scp -r gluon/gluon-luci-private-wifi/files/* root@192.168.1.1:/`
I did not create a build yet.
