### PR TITLE
gluon-core: add unique node_id

### DIFF
--- a/gluon/gluon-announce/files/lib/gluon/announce/announce.d/node_id
+++ b/gluon/gluon-announce/files/lib/gluon/announce/announce.d/node_id
@@ -1,0 +1,1 @@
+return require('gluon.sysconfig').primary_mac:gsub(':', '')


### PR DESCRIPTION
This adds a new sysconfig value called `node_id`. `node_id` is an
integer uniquely identifying a particular node. On nodes having a
primary MAC this MAC will be converted to an integer and saved as
`node_id`. The value is opaque. It must not be converted back into
a MAC address.

`node_id` should be sent in all alfred and announced packets to
ensure clients can link the data to a particular node.
