### PR TITLE
Fixed bug which led to empty ath9k-workaround crontab file

### DIFF
--- a/gluon/gluon-ath9k-workaround/files/lib/gluon/upgrade/ath9k-workaround/invariant/010-monitor
+++ b/gluon/gluon-ath9k-workaround/files/lib/gluon/upgrade/ath9k-workaround/invariant/010-monitor
@@ -5,8 +5,10 @@ local uci = require 'luci.model.uci'
 
 local c = uci.cursor()
 
-local f = io.open('/lib/gluon/cron/ath9k-workaround','w')
-if f and site.monitor ~= nil then
-  f:write('* * * * * /usr/sbin/ath9k-workaround | nc ' .. site.monitor)
-  f:close()
+if site.monitor ~= nil then
+  local f = io.open('/lib/gluon/cron/ath9k-workaround','w')
+  if f ~= nil then
+    f:write('* * * * * /usr/sbin/ath9k-workaround | nc ' .. site.monitor)
+    f:close()
+  end
 end


### PR DESCRIPTION
The crontab file was opened in write mode but in the case where no monitor is defined it would leave an empty file.
