### PR TITLE
Add javascript to handle input of a pair of map coordinates

### DIFF
--- a/gluon/gluon-config-mode/files/usr/lib/lua/luci/view/gluon-config-mode/cbi/wizard.htm
+++ b/gluon/gluon-config-mode/files/usr/lib/lua/luci/view/gluon-config-mode/cbi/wizard.htm
@@ -62,7 +62,18 @@
 		<%- if not self.cancel then -%><%-:Cancel-%><%-else-%><%=self.cancel%><%end-%>
 	" />
 <% end %>
-		<script type="text/javascript">cbi_d_update();</script>
+		<script type="text/javascript">
+			cbi_d_update();
+			window.onload = function() {
+				var spread_latitude = document.getElementById('cbid.wizard.1._latitude');
+				var spread_longitude = document.getElementById('cbid.wizard.1._longitude');
+				spread_latitude.addEventListener('change', function() {
+					p=spread_latitude.value.trim().split(/[ ,]+/);
+					spread_latitude.value = p[0];
+					spread_longitude.value = p[1];
+				});
+			}
+		</script>
 	</div>
 </form>
 <% end %>


### PR DESCRIPTION
... and move longitude to second field.

This will add an event listener to the first latitude field so you can enter a string with a pair of coordinates (for example "54.123456 10.123456") and this string will automatically be split in two, then the first field value for latitude will be shortened to "54.123456" and the second part ("10.123456") will be entered in the second longitude field.
