### PR TITLE
mesh-batman-adv-core: add clientcount statistics

### DIFF
--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/clients
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/clients
@@ -1,0 +1,20 @@
+local list = io.lines("/sys/kernel/debug/batman_adv/bat0/transtable_local")
+
+local count = 0
+local wifi = 0
+for line in list do
+  local mac, _, flags, lastseen = line:match("^ %* ([0-9a-f:]+) *(.- )%[(.-)%] +(%d+%.%d+)")
+  if mac then
+    if not flags:match('P') then
+      count = count + 1
+
+      if flags:match('W') then
+        wifi = wifi +1
+      end
+    end
+  end
+end
+
+return { total = count
+       , wifi  = wifi
+       }


### PR DESCRIPTION
This adds

  "client" { "total": <int>, "wifi": <int>" }

to statistics.d. "total" will be the number of clients connected.
"wifi" will be the number of clients connected over wifi. I.e. "total"
will always be equal to or greater than "wifi".

The node will not count itself.
