### PR TITLE
gluon-status-page: Add meta tag for viewport

### DIFF
--- a/gluon/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/status
+++ b/gluon/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/status
@@ -19,6 +19,7 @@ cat <<EOF
 <html>
   <head>
     <title>$(cat /proc/sys/kernel/hostname)</title>
+    <meta name="viewport" content="width=device-width">
   </head>
   <body>
 EOF


### PR DESCRIPTION
This enables mobile devices to auto adjust the viewport.
