### PR TITLE
gluon-core: Remove VERSION_DIR hack

### DIFF
--- a/gluon/gluon-core/files/etc/uci-defaults/zzz-gluon-upgrade
+++ b/gluon/gluon-core/files/etc/uci-defaults/zzz-gluon-upgrade
@@ -11,10 +11,6 @@ else
 	HAS_LEGACY=
 fi
 
-
-# Temporary fix for broken upgrades (happened between 20140225 and 20140226, remove next week)
-if [ -f "$VERSION_DIR" ]; then rm "$VERSION_DIR"; fi
-
 mkdir -p "$VERSION_DIR"
 
 


### PR DESCRIPTION
As the (removed) comment said, this was a one-time-hack that was obsoleted long ago.
