### PR TITLE
mesh-vpn-fastd: enable from site.conf

### DIFF
--- a/gluon/gluon-mesh-vpn-fastd/check_site.lua
+++ b/gluon/gluon-mesh-vpn-fastd/check_site.lua
@@ -11,3 +11,4 @@ local function check_peer(k, _)
 end
 
 need_table('fastd_mesh_vpn.backbone.peers', check_peer)
+need_boolean('fastd_mesh_vpn.enabled', false)

--- a/gluon/gluon-mesh-vpn-fastd/files/lib/gluon/upgrade/mesh-vpn-fastd/initial/010-mesh-vpn-fastd
+++ b/gluon/gluon-mesh-vpn-fastd/files/lib/gluon/upgrade/mesh-vpn-fastd/initial/010-mesh-vpn-fastd
@@ -1,0 +1,14 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require 'luci.model.uci'
+local c = uci.cursor()
+
+c:section('fastd', 'fastd', 'mesh_vpn',
+	  {
+		  enabled = site.fastd_mesh_vpn.enabled and 1 or 0
+	  }
+)
+
+c:save('fastd')
+c:commit('fastd')


### PR DESCRIPTION
This patch allows fastd's enabled flag's default value to be set from
site.conf.
