### PR TITLE
mesh-batman-adv-core: disable igmp_snooping on br-client

### DIFF
--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/011-mesh
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/011-mesh
@@ -35,6 +35,7 @@ if not uci:get('network', 'client') then
   )
 end
 
+uci:set('network', 'client', 'igmp_snooping', 0)
 uci:set('network', 'client', 'macaddr', sysconfig.primary_mac)
 uci:set('network', 'client', 'peerdns', 1)
 


### PR DESCRIPTION
IGMP snooping causes serious trouble with IPv6 neighbour discovery.
