### PR TITLE
gluon-authorized-keys: add keys from site.conf

### DIFF
--- a/gluon/gluon-authorized-keys/Makefile
+++ b/gluon/gluon-authorized-keys/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-authorized-keys
+PKG_VERSION:=2
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(GLUONDIR)/include/package.mk
+
+define Package/gluon-authorized-keys
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Fill /etc/dropbear/authorized_keys from site.conf
+  DEPENDS:=+gluon-core
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-authorized-keys/install
+	$(CP) ./files/* $(1)/
+endef
+
+define Package/gluon-authorized-keys/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-authorized-keys))

--- a/gluon/gluon-authorized-keys/check_site.lua
+++ b/gluon/gluon-authorized-keys/check_site.lua
@@ -1,0 +1,1 @@
+need_string_array 'authorized_keys'

--- a/gluon/gluon-authorized-keys/files/lib/gluon/upgrade/authorized-keys/invariant/010-authorized-keys
+++ b/gluon/gluon-authorized-keys/files/lib/gluon/upgrade/authorized-keys/invariant/010-authorized-keys
@@ -1,0 +1,22 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local file = '/etc/dropbear/authorized_keys'
+
+local keys = {}
+
+function load_keys()
+  for line in io.lines(file) do
+    keys[line] = true
+  end
+end
+
+pcall(load_keys)
+
+local f = io.open(file, 'a')
+for _, key in ipairs(site.authorized_keys) do
+  if not keys[key] then
+    f:write(key .. '\n')
+  end
+end
+f:close()


### PR DESCRIPTION
This package will run as invariant script after each upgrade and copy
all keys from site.conf's authorized_keys entry to
/etc/dropbear/authorized_keys.

Existing keys will be preserved.

The site.conf entry 'authorized_keys' is required (if this package is
selected) and must contain a list of strings, each representing a line
of the resulting file.
