### PR TITLE
Mesh-VPN Bandbreite in Prozent

### DIFF
--- a/gluon/gluon-simple-tc/Makefile
+++ b/gluon/gluon-simple-tc/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-simple-tc
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Bandwidth limit support
-  DEPENDS:=+gluon-core +kmod-sched +libnl-tiny
+  DEPENDS:=+gluon-core +kmod-sched +libnl-tiny +iperf
 endef
 
 define Package/gluon-simple-tc/description

--- a/gluon/gluon-simple-tc/files/etc/hotplug.d/net/50-gluon-simple-tc
+++ b/gluon/gluon-simple-tc/files/etc/hotplug.d/net/50-gluon-simple-tc
@@ -16,6 +16,19 @@ tc_interface() {
 
 	config_get limit_ingress "$iface" limit_ingress
 	config_get limit_egress "$iface" limit_egress
+	config_get autotest "$iface" autotest
+
+	# Limits per % -> Langzeitmessung im Hintergrund
+	if [ 0$autotest -eq 1 ] ; then
+		echo "$0 autotest allowed in uci / site.conf " >>/tmp/auto-tc-output
+		if [ "0$limit_ingress" -lt 100 ] || [ "0$limit_egress" -lt 100 ] ; then
+			echo "autotest needed (wert <100) " >>/tmp/auto-tc-output
+			/lib/gluon/auto-tc/check-and-update.lua >>/tmp/auto-tc-output &
+			# Minimalfallback für den Fall, das die Messungen schief gehen
+			[ "$limit_ingress" ] && [ "0$limit_ingress" -lt 100 ] && limit_ingress=400
+			[ "$limit_egress" ]  && [ "0$limit_egress" -lt 100 ]  && limit_egress=100
+		fi
+	fi
 
 	[ "$limit_ingress" ] || limit_ingress=-
 	[ "$limit_egress" ] || limit_egress=-

--- a/gluon/gluon-simple-tc/files/etc/hotplug.d/net/50-gluon-simple-tc
+++ b/gluon/gluon-simple-tc/files/etc/hotplug.d/net/50-gluon-simple-tc
@@ -20,10 +20,8 @@ tc_interface() {
 
 	# Limits per % -> Langzeitmessung im Hintergrund
 	if [ 0$autotest -eq 1 ] ; then
-		echo "$0 autotest allowed in uci / site.conf " >>/tmp/auto-tc-output
 		if [ "0$limit_ingress" -lt 100 ] || [ "0$limit_egress" -lt 100 ] ; then
-			echo "autotest needed (wert <100) " >>/tmp/auto-tc-output
-			/lib/gluon/auto-tc/check-and-update.lua >>/tmp/auto-tc-output &
+			/lib/gluon/auto-tc/check-and-update.lua &>/tmp/auto-tc-output &
 			# Minimalfallback für den Fall, das die Messungen schief gehen
 			[ "$limit_ingress" ] && [ "0$limit_ingress" -lt 100 ] && limit_ingress=400
 			[ "$limit_egress" ]  && [ "0$limit_egress" -lt 100 ]  && limit_egress=100

--- a/gluon/gluon-simple-tc/files/lib/gluon/auto-tc/check-and-update.lua
+++ b/gluon/gluon-simple-tc/files/lib/gluon/auto-tc/check-and-update.lua
@@ -1,0 +1,88 @@
+#!/usr/bin/lua
+
+site = require 'gluon.site_config'
+c=site.simple_tc.mesh_vpn.autotest
+
+local meshvpn_name = "mesh_vpn"
+local uci = require('luci.model.uci').cursor()
+interface=uci:get("gluon-simple-tc", meshvpn_name, "ifname")
+limit_in=uci:get("gluon-simple-tc", meshvpn_name, "limit_ingress")
+limit_up=uci:get("gluon-simple-tc", meshvpn_name, "limit_egress")
+last_test=uci:get("gluon-simple-tc", meshvpn_name, "last_autotest")
+
+for i=1,18 do	-- give ntp some time to work
+	now=os.time()
+	if (now >1400000000) then -- ntp ok, so save timestamp to avoid measuring too often
+		uci:section('gluon-simple-tc', 'interface', "mesh_vpn", { last_autotest = now } )
+		uci:save('gluon-simple-tc')
+		uci:commit('gluon-simple-tc')
+		if (not last_test) then last_test=now end
+		rebootstoofast= ( (now - last_test) < 7*86400 )
+		break
+	else
+		os.execute("sleep 10")
+	end
+end
+
+math.randomseed (os.time())
+
+maxtries=4
+maxdown=400
+maxup=100
+delay=9600
+
+success_down, success_up = 0, 0
+
+-- if no own server -> use fallbacks
+if (not c.iperf_own) then c.iperf_own=#c.iperf_server end
+if (not c.download_own) then c.iperf_own=#c.download_links end
+
+for round=1,9 do
+	iserver, downloadserver = math.random(c.iperf_own), math.random(c.download_own)	-- beginn with own servers
+	io.write(round.." ("..os.date("%H:%M %m-%d").."): ")
+	
+	if limit_in-1 < 99 and #c.download_links then
+		for try=1,maxtries do
+			time=io.open("/proc/uptime"):read('*n')
+			erg=os.execute ("wget -q ".. c.download_links[downloadserver] .. " -O /dev/null ")
+			time=io.open("/proc/uptime"):read('*n')-time
+			if erg==0 then break else downloadserver=math.random(#c.download_links) end
+		end
+		if erg==0 then
+			speed=math.floor(c.download_filesize/time*8/1000)
+			if speed > maxdown then maxdown=speed end
+			success_down = success_down + 1
+			io.write ("DownServer "..downloadserver..": "..speed.."\t"..maxdown.."\t")
+		else
+			io.write ("Probleme beim Downloadtest\t\t")
+		end
+	end
+
+	if limit_up-1 < 99 and #c.iperf_server then
+		for try=1,maxtries do
+			speed=io.popen("iperf -fk -x SMCV -c ".. c.iperf_server[iserver]..'|tail -1|sed "s/ */ /g"|cut -d" " -f8'):read("*n")
+			if speed then break else iserver=math.random(#c.iperf_server) end
+		end
+		if speed then
+			if speed > maxup then maxup=speed end
+			success_up = success_up + 1
+			io.write ("UpServer "..iserver..": "..speed.."\t"..maxup)
+		else
+			io.write ("Probleme beim Uploadtest")
+		end
+	end
+
+	io.write("\ngluon-simple-tc "..interface.." "..math.floor(maxdown*limit_in/100).." "..math.floor(maxup*limit_up/100).."\n")
+	os.execute("gluon-simple-tc "..interface.." "..math.floor(maxdown*limit_in/100).." "..math.floor(maxup*limit_up/100))
+
+	-- if we have had some successfull tries, but the router rebooted too fast
+	if rebootstoofast and (success_up>2) and (success_down>2) then
+		io.write("\nNote: Router rebooted after less than a week uptime, switching to slower adaption")
+		delay=delay+86400
+		rebootstoofast=false
+	end
+	io.write "\n-----\n"
+	io.flush()
+	os.execute("sleep "..delay)
+end
+

--- a/gluon/gluon-simple-tc/files/lib/gluon/auto-tc/check-and-update.lua
+++ b/gluon/gluon-simple-tc/files/lib/gluon/auto-tc/check-and-update.lua
@@ -72,7 +72,6 @@ for round=1,9 do
 		end
 	end
 
-	io.write("\ngluon-simple-tc "..interface.." "..math.floor(maxdown*limit_in/100).." "..math.floor(maxup*limit_up/100).."\n")
 	os.execute("gluon-simple-tc "..interface.." "..math.floor(maxdown*limit_in/100).." "..math.floor(maxup*limit_up/100))
 
 	-- if we have had some successfull tries, but the router rebooted too fast

--- a/gluon/gluon-simple-tc/files/lib/gluon/status-page/www/cgi-bin/auto-tc
+++ b/gluon/gluon-simple-tc/files/lib/gluon/status-page/www/cgi-bin/auto-tc
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+model="$(lua -e 'print(require("platform_info").get_model())')"
+
+escape_html() {
+  sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g; s/'"'"'/\&#39;/g'
+}
+
+linknodes() {
+  PREFIX=$(uci get network.local_node_route6.target | cut -d: -f 1-4)
+  sed 's#\([0-9a-f]\{2\}\):\([0-9a-f]\{2\}\):\([0-9a-f]\{2\}\):\([0-9a-f]\{2\}\):\([0-9a-f]\{2\}\):\([0-9a-f]\{2\}\)#<a href="http://['$PREFIX':\1\2:\3ff:fe\4:\5\6]/">&</a>#g'
+}
+
+echo Content-type: text/html
+echo ""
+
+cat <<EOF
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>$(cat /proc/sys/kernel/hostname)</title>
+  </head>
+  <body>
+EOF
+
+echo "<h1>$(cat /proc/sys/kernel/hostname)</h1>"
+
+echo "<pre>"
+
+echo "Model: $model" | escape_html
+echo "Firmware release: $(cat /lib/gluon/release | escape_html)"
+echo "<p>"
+
+cat /tmp/auto-tc*
+
+echo "</pre>"
+
+
+cat <<EOF
+  </body>
+</html>
+EOF

--- a/gluon/gluon-simple-tc/files/lib/gluon/upgrade/simple-tc/invariant/010-site-defaults
+++ b/gluon/gluon-simple-tc/files/lib/gluon/upgrade/simple-tc/invariant/010-site-defaults
@@ -14,6 +14,7 @@ for name, config in pairs(site.simple_tc) do
 		enabled = config.enabled and 1 or 0,
 		limit_egress = config.limit_egress,
 		limit_ingress = config.limit_ingress,
+		autotest = config.autotest.enabled and 1 or 0,
 	      }
     )
   end


### PR DESCRIPTION
Erweitert simple_tc um die Möglichkeit, die fürs Mesh-VPN freigegebene Bandbreite in Prozent anzugeben.

Dazu werden Werte <100 einfach als Prozenteingabe gewertet, Freigaben mit weniger als 100kbit
nutzen de facto sowieso eher wenig.

Die Hauptarbeit (sprich das Bandbreite-Raten) macht das Script

/lib/gluon/auto-tc/check-and-update.lua

Download-Bandbreite wird durch einen simplen Test-Download geschätzt, Upload durch einen
Testlauf zu einem iperf2-Server.

Die zu nutzenden Server (und ob diese Möglichkeit überhaupt aktiv ist), wird in der
site.conf festgelegt, der Interface-Bereich von simple_tc wurde dazu um das Array
autotest erweitert:

	simple_tc = {
		mesh_vpn = {
			ifname = 'mesh-vpn',
			enabled = false,
			limit_egress = 200,
			limit_ingress = 3000,
			autotest={
				enabled = true,
				iperf_server={  "192.168.2.3",
						"192.168.108.204",
						"iperf.scottlinux.com",
						"iperf.eltel.net",
						"mptcp.info.ucl.ac.be"
				},
				iperf_own=2,

				download_filesize=10485760,
				download_links={"http://192.168.108.204/downloads/Bandbreitentest-10MB",
					"http://www.connect2000.de/download/test_10MB.bin",
					"http://www.speedtest.qsc.de/10MB.qsc",
					"http://speedtest.netcologne.de/test_10mb.bin",
					"http://vhost2.hansenet.de/10_mb_file.bin" },
				download_own=1,
			},
		},
	},

iperf_own / download_own definieren dabei die 'eigenen' Server, die für die Tests bevorzugt
werden, nur bei Fehlern wird auf einen (oder mehrere) zufälligen Server zurückgegriffen.