### PR TITLE
gluon-core: remove nixio dependency

### DIFF
--- a/gluon/gluon-announce/Makefile
+++ b/gluon/gluon-announce/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/gluon-announce
   SECTION:=gluon
   CATEGORY:=Gluon
-  DEPENDS:=+gluon-core +luci-lib-json +lua-ethtool-stats
+  DEPENDS:=+gluon-core +luci-lib-json +luci-lib-nixio +lua-ethtool-stats
   TITLE:=Lua scripts announcing various information
 endef
 

--- a/gluon/gluon-core/Makefile
+++ b/gluon/gluon-core/Makefile
@@ -12,7 +12,7 @@ define Package/gluon-core
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Base files of Gluon
-  DEPENDS:=+gluon-config +lua-platform-info +luci-lib-nixio +odhcp6c +firewall
+  DEPENDS:=+gluon-config +lua-platform-info +odhcp6c +firewall
 endef
 
 define Package/gluon-core/description

--- a/gluon/gluon-core/files/usr/lib/lua/gluon/util.lua
+++ b/gluon/gluon-core/files/usr/lib/lua/gluon/util.lua
@@ -27,7 +27,6 @@ local os = os
 local string = string
 local tonumber = tonumber
 
-local nixio = require 'nixio'
 local sysconfig = require 'gluon.sysconfig'
 
 
@@ -71,7 +70,8 @@ end
 -- (4, 0): mesh VPN
 function generate_mac(f, i)
   local m1, m2, m3, m4, m5, m6 = string.match(sysconfig.primary_mac, '(%x%x):(%x%x):(%x%x):(%x%x):(%x%x):(%x%x)')
-  m1 = nixio.bit.bor(tonumber(m1, 16), 0x02)
+  m1 = tonumber(m1, 16)
+  m1 = math.floor(m1/4) * 4 + 2 + m1 % 2
   m2 = (tonumber(m2, 16)+f) % 0x100
   m3 = (tonumber(m3, 16)+i) % 0x100
 

--- a/gluon/gluon-status-page/Makefile
+++ b/gluon/gluon-status-page/Makefile
@@ -12,7 +12,7 @@ define Package/gluon-status-page
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Adds a status page showing information about the node.
-  DEPENDS:=+gluon-core +gluon-neighbour-info +uhttpd
+  DEPENDS:=+gluon-core +gluon-neighbour-info +uhttpd +luci-lib-nixio
 endef
 
 define Package/gluon-status-page/description

--- a/gluon/gluon-wan-dnsmasq/Makefile
+++ b/gluon/gluon-wan-dnsmasq/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-wan-dnsmasq
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Support for a secondary DNS server using the WAN interface
-  DEPENDS:=+gluon-core +dnsmasq +libpacketmark
+  DEPENDS:=+gluon-core +dnsmasq +libpacketmark +luci-lib-nixio
 endef
 
 define Package/gluon-wan-dnsmasq/description


### PR DESCRIPTION
luci-lib-nixio pulls in luci-base, yet only a single function from
nixio was used. In my test case this saved roughly 200kb from the
compressed image when compiling a bare gluon (i.e. no configmode).