### PR TITLE
add packages gluon-node-purpose & gluon-luci-node-purpose

### DIFF
--- a/gluon/gluon-luci-node-purpose/Makefile
+++ b/gluon/gluon-luci-node-purpose/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-luci-node-purpose
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-luci-node-purpose
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+gluon-luci-admin +gluon-node-purpose
+  TITLE:=UI for specifying node purpose
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-luci-node-purpose/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-luci-node-purpose))

--- a/gluon/gluon-luci-node-purpose/files/usr/lib/lua/luci/controller/admin/nodepurpose.lua
+++ b/gluon/gluon-luci-node-purpose/files/usr/lib/lua/luci/controller/admin/nodepurpose.lua
@@ -1,0 +1,5 @@
+module("luci.controller.admin.nodepurpose", package.seeall)
+
+function index()
+	entry({"admin", "nodepurpose"}, cbi("admin/nodepurpose"), "Verwendungszweck", 20)
+end

--- a/gluon/gluon-luci-node-purpose/files/usr/lib/lua/luci/model/cbi/admin/nodepurpose.lua
+++ b/gluon/gluon-luci-node-purpose/files/usr/lib/lua/luci/model/cbi/admin/nodepurpose.lua
@@ -1,0 +1,35 @@
+local f, s, o, role
+local uci = luci.model.uci.cursor()
+local config = 'gluon-node-info'
+
+-- where to read the configuration from
+local role = uci:get(config, uci:get_first(config, "purpose"), "role")
+
+f = SimpleForm("purpose", "Verwendungszweck")
+f.reset = false
+f.template = "admin/expertmode"
+f.submit = "Fertig"
+
+s = f:section(SimpleSection, nil, [[
+Wenn dein Freifunk-Router eine besondere Rolle im Freifunk Netz einnimmt, kannst du diese hier angeben.
+Das kann z.B. die "Backbone" Rolle sein, damit er auf der Freifunk-Knotenkarte entsprechend gekennzeichnet wird.
+Setze die Rolle nur, wenn du weißt was du machst. Informiere dich bitte vorher, was die entsprechenden Rollen im
+Freifunk-Netz bewirken.
+]])
+
+o = s:option(ListValue, "role", "Rolle")
+o.default = role
+o.rmempty = false
+o:value("node", "Normaler Knoten")
+o:value("backbone", "Backbone Knoten")
+
+function f.handle(self, state, data)
+  if state == FORM_VALID then
+    uci:set(config, uci:get_first(config, "purpose"), data.role)
+
+    uci:save(config)
+    uci:commit(config)
+  end
+end
+
+return f

--- a/gluon/gluon-node-purpose/Makefile
+++ b/gluon/gluon-node-purpose/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-node-purpose
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-node-purpose
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Add /etc/config/gluon-node-purpose to uci
+  DEPENDS:=+gluon-core +gluon-node-info
+endef
+
+define Package/gluon-node-purpose/description
+	This package adds the section purpose to /etc/config/gluon-node-info.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-node-purpose/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-node-purpose))

--- a/gluon/gluon-node-purpose/files/lib/gluon/announce/nodeinfo.d/purpose
+++ b/gluon/gluon-node-purpose/files/lib/gluon/announce/nodeinfo.d/purpose
@@ -1,0 +1,4 @@
+local role = uci:get_first('gluon-node-info', 'purpose', 'role', '')
+if role ~= '' then
+	return { role = role }
+end

--- a/gluon/gluon-node-purpose/files/lib/gluon/upgrade/node-purpose/initial/010-node-purpose
+++ b/gluon/gluon-node-purpose/files/lib/gluon/upgrade/node-purpose/initial/010-node-purpose
@@ -1,0 +1,20 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require ('luci.model.uci').cursor()
+
+local config = 'gluon-node-info'
+
+if not site.default_role then
+  role = ''
+else
+  role = site.default_role
+end
+
+if role ~= '' then
+  uci:section(config, 'purpose')
+  uci:set(config, uci:get_first(config, 'purpose'), 'role', role)
+end
+
+uci:save(config)
+uci:commit(config)

--- a/gluon/gluon-node-purpose/files/lib/gluon/upgrade/node-purpose/invariant/010-node-purpose
+++ b/gluon/gluon-node-purpose/files/lib/gluon/upgrade/node-purpose/invariant/010-node-purpose
@@ -1,0 +1,23 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require('luci.model.uci').cursor()
+
+local config = 'gluon-node-info'
+
+if not site.default_role then
+  role = ''
+else
+  role = site.default_role
+end
+
+if not uci:get_first(config, 'purpose') then
+  uci:section(config, 'purpose')
+end
+
+if role ~= '' then
+  uci:set(config, uci:get_first(config, 'purpose'), 'role', role)
+end
+
+uci:save(config)
+uci:commit(config)


### PR DESCRIPTION
This Pull Request adds two packages, "gluon-node-purpose" and "gluon-luci-node-purpose".

Inside the mesh we want to distinguish normal nodes from other ones like backbone nodes, service nodes (servers like the one for the node map) and gateways.
This will give the facility to react on, especially inside the node map:
 - node detail view
 - node counts/statistics
 - display backbone links in another way (see http://map.freifunk-mwu.de/graph.html#mz-uniklinik)
 - display separate lists (see http://map.freifunk-mwu.de/list.html)

Maybe other things are possible at the backend while parsing alfred data in future.

Package "gluon-node-purpose":
Depends on gluon-node-info and a new config "default_role" in the site.conf. If "default_role" in site.conf is set the section "purpose" will be added to /etc/config/gluon-node-info as well as the option "role" with the value of "default_role". Manual overrides will be kept after an upgrade.

Package "gluon-luci-node-purpose":
Depends on gluon-node-purpose. Will add a new form to the expert config mode where it is possible to select the node role form a dropdown list.

At the moment there are two node roles defined:
- "node" / normal node, the most case
- "backbone" / backbone node

I have tested this new packages with the current master and everything worked as espected.