### PR TITLE
add section "system" to gluon-node-info with new option "role" and luci package to change role via config mode

### DIFF
--- a/gluon/gluon-luci-node-role/Makefile
+++ b/gluon/gluon-luci-node-role/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-luci-node-role
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(GLUONDIR)/include/package.mk
+
+define Package/gluon-luci-node-role
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+gluon-luci-admin +gluon-node-info
+  TITLE:=UI for specifying node role
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-luci-node-role/install
+	$(CP) ./files/* $(1)/
+endef
+
+define Package/gluon-luci-node-role/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-luci-node-role))

--- a/gluon/gluon-luci-node-role/check_site.lua
+++ b/gluon/gluon-luci-node-role/check_site.lua
@@ -1,0 +1,8 @@
+local function check_role(k, _)
+   local role = string.format('roles.list[%q]', k)
+
+   need_string(role)
+end
+
+need_string('roles.default')
+need_table('roles.list', check_role)

--- a/gluon/gluon-luci-node-role/files/usr/lib/lua/luci/controller/admin/noderole.lua
+++ b/gluon/gluon-luci-node-role/files/usr/lib/lua/luci/controller/admin/noderole.lua
@@ -1,0 +1,5 @@
+module("luci.controller.admin.noderole", package.seeall)
+
+function index()
+	entry({"admin", "noderole"}, cbi("admin/noderole"), "Verwendungszweck", 20)
+end

--- a/gluon/gluon-luci-node-role/files/usr/lib/lua/luci/model/cbi/admin/noderole.lua
+++ b/gluon/gluon-luci-node-role/files/usr/lib/lua/luci/model/cbi/admin/noderole.lua
@@ -1,0 +1,36 @@
+local f, s, o
+local site = require 'gluon.site_config'
+local uci = luci.model.uci.cursor()
+local config = 'gluon-node-info'
+
+-- where to read the configuration from
+local role = uci:get(config, uci:get_first(config, "system"), "role")
+
+f = SimpleForm("role", "Verwendungszweck")
+f.reset = false
+f.template = "admin/expertmode"
+f.submit = "Fertig"
+
+s = f:section(SimpleSection, nil, [[
+Wenn dein Freifunk-Router eine besondere Rolle im Freifunk Netz einnimmt, kannst du diese hier angeben.
+Bringe bitte zuvor in Erfahrung welche Auswirkungen die zur Verfügung stehenden Rollen im Freifunk-Netz haben.
+Setze die Rolle nur, wenn du weißt was du machst.
+]])
+
+o = s:option(ListValue, "role", "Rolle")
+o.default = role
+o.rmempty = false
+for role, prettyname in pairs(site.roles.list) do
+  o:value(role, prettyname)
+end
+
+function f.handle(self, state, data)
+  if state == FORM_VALID then
+    uci:set(config, uci:get_first(config, "system"), "role", data.role)
+
+    uci:save(config)
+    uci:commit(config)
+  end
+end
+
+return f

--- a/gluon/gluon-node-info/Makefile
+++ b/gluon/gluon-node-info/Makefile
@@ -6,7 +6,7 @@ PKG_RELEASE:=1
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
-include $(INCLUDE_DIR)/package.mk
+include $(GLUONDIR)/include/package.mk
 
 define Package/gluon-node-info
   SECTION:=gluon
@@ -31,6 +31,11 @@ endef
 
 define Package/gluon-node-info/install
 	$(CP) ./files/* $(1)/
+endef
+
+define Package/gluon-node-info/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
 endef
 
 $(eval $(call BuildPackage,gluon-node-info))

--- a/gluon/gluon-node-info/check_site.lua
+++ b/gluon/gluon-node-info/check_site.lua
@@ -1,0 +1,8 @@
+local function check_role(k, _)
+   local role = string.format('roles.list[%q]', k)
+
+   need_string(role)
+end
+
+need_string('roles.default', false)
+need_table('roles.list', check_role, false)

--- a/gluon/gluon-node-info/files/etc/config/gluon-node-info
+++ b/gluon/gluon-node-info/files/etc/config/gluon-node-info
@@ -2,3 +2,5 @@ config location
 	option share_location '0'
 
 config owner
+
+config system

--- a/gluon/gluon-node-info/files/lib/gluon/announce/nodeinfo.d/system/role
+++ b/gluon/gluon-node-info/files/lib/gluon/announce/nodeinfo.d/system/role
@@ -1,0 +1,4 @@
+local role = uci:get_first('gluon-node-info', 'system', 'role', '')
+if role ~= '' then
+        return role
+end

--- a/gluon/gluon-node-info/files/lib/gluon/upgrade/node-info/invariant/001-node-system
+++ b/gluon/gluon-node-info/files/lib/gluon/upgrade/node-info/invariant/001-node-system
@@ -1,0 +1,11 @@
+#!/usr/bin/lua
+
+local uci = require('luci.model.uci').cursor()
+
+local config = 'gluon-node-info'
+
+if not uci:get_first(config, 'system') then
+  uci:section(config, 'system')
+  uci:save(config)
+  uci:commit(config)
+end

--- a/gluon/gluon-node-info/files/lib/gluon/upgrade/node-info/invariant/010-node-role
+++ b/gluon/gluon-node-info/files/lib/gluon/upgrade/node-info/invariant/010-node-role
@@ -1,0 +1,19 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require('luci.model.uci').cursor()
+
+local config = 'gluon-node-info'
+local role = uci:get(config, uci:get_first(config, 'system'), 'role')
+
+if site.roles then
+  default_role = site.roles.default
+else
+  default_role = ''
+end
+
+if not role then
+  uci:set(config, uci:get_first(config, 'system'), 'role', default_role)
+  uci:save(config)
+  uci:commit(config)
+end


### PR DESCRIPTION
This Pull Request adds the section "system" to /etc/config/gluon-node-info and a new option "role" within "system".

Inside the mesh we want to distinguish normal nodes from other ones like backbone nodes, service nodes (servers like the one for the node map) and gateways.
This will give a facility to react differently on different nodes, especially at node map:
 - node detail view
 - node counts/statistics
 - display backbone links in another way
   - see http://map.freifunk-mwu.de/graph.html#mz-uniklinik for graph
   - see http://map.freifunk-mwu.de/geomap.html#lat=49.9926050006&lon=8.2622981071472 for geomap
 - display separate lists (see http://map.freifunk-mwu.de/list.html)

Maybe other things are possible at the backend while parsing alfred data in future.

A new section in site.conf will be necessary:

```
...
  roles = {
    default = 'node',
    list = {
        node = 'Normaler Knoten',
        backbone = 'Backbone Knoten',
        service = 'Service Knoten',
    },
  },
....
```
This is just an example and every community will be able to define here their own node roles as they like.

Node role:
Depends on the new section "site.roles" in the site.conf. In case the role is not set in `/etc/config/gluon-node-info` the invariant script "010-node-role" will set the role to "site.roles.default".

Package "gluon-luci-node-role":
Depends on gluon-node-info. Will add a new form to the expert config mode where it is possible to select the node roles specified in site.conf from a dropdown list. See the attached screenshot.
![node_role](https://cloud.githubusercontent.com/assets/2283789/5695349/35e4add8-999e-11e4-879d-5ddd935aabd4.png)
