### PR TITLE
gluon-announced: add dependency to gluon-announce

### DIFF
--- a/gluon/gluon-announced/Makefile
+++ b/gluon/gluon-announced/Makefile
@@ -12,7 +12,7 @@ define Package/gluon-announced
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=announced support
-  DEPENDS:=
+  DEPENDS:=+gluon-announce
 endef
 
 define Package/gluon-announced/description


### PR DESCRIPTION
the gluon-announced package installs a hotplug script
that uses announce.lua from the gluon-announce package.

So we need to include gluon-announce as dependency.

Signed-off-by: flokli <florian@darmstadt.freifunk.net>