### PR TITLE
gluon-announced: rename DEVLIST file to gluon-announced.devs

### DIFF
--- a/gluon/gluon-announced/files/etc/hotplug.d/iface/10-gluon-announced
+++ b/gluon/gluon-announced/files/etc/hotplug.d/iface/10-gluon-announced
@@ -3,7 +3,7 @@
 . /usr/share/libubox/jshn.sh
 . /lib/functions/service.sh
 
-DEVLIST=/var/run/gluon-announce.devs
+DEVLIST=/var/run/gluon-announced.devs
 DAEMON=/usr/bin/gluon-announced
 
 ifname_to_dev () {


### PR DESCRIPTION
was gluon-announce.devs before

Signed-off-by: flokli <florian@darmstadt.freifunk.net>