### PR TITLE
allow batadv to run inside wifi-iface VLANs

### DIFF
--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
@@ -27,16 +27,14 @@ local function configure_radio(radio, index, config)
 
   local mesh = 'mesh_' .. radio
   uci:delete('network', mesh)
+  uci:delete('network', mesh .. '_vbatadv')
 
   if config.vlan_batadv then
-	local meshif = mesh .. '_' .. config.vlan_batadv
-	local meshifn = '@' .. mesh .. '.' .. config.vlan_batadv
 	uci:section('network', 'interface', mesh,
 		{ proto = 'none', mtu = '1536',})
-	uci:delete('network', meshif)
-	uci:section('network', 'interface', meshif,
+	uci:section('network', 'interface', mesh .. '_vbatadv',
 	      {
-		ifname = meshifn,
+		ifname = '@' .. mesh .. '.' .. config.vlan_batadv,
 		proto = 'batadv',
 		mtu = '1532',
 		mesh = 'bat0',

--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
@@ -27,13 +27,29 @@ local function configure_radio(radio, index, config)
 
   local mesh = 'mesh_' .. radio
   uci:delete('network', mesh)
-  uci:section('network', 'interface', mesh,
+
+  if config.vlan_batadv then
+	local meshif = mesh .. '_' .. config.vlan_batadv
+	local meshifn = '@' .. mesh .. '.' .. config.vlan_batadv
+	uci:section('network', 'interface', mesh, { proto = 'none', })
+	uci:delete('network', meshif)
+	uci:section('network', 'interface', meshif,
+	      {
+		ifname = meshifn,
+		proto = 'batadv',
+		mtu = '1528',
+		mesh = 'bat0',
+	      }
+	)
+  else
+	uci:section('network', 'interface', mesh,
 	      {
 		proto = 'batadv',
 		mtu = '1528',
 		mesh = 'bat0',
 	      }
-  )
+	)
+  end
 
   uci:delete('wireless', mesh)
   uci:section('wireless', 'wifi-iface', mesh,

--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
@@ -31,13 +31,14 @@ local function configure_radio(radio, index, config)
   if config.vlan_batadv then
 	local meshif = mesh .. '_' .. config.vlan_batadv
 	local meshifn = '@' .. mesh .. '.' .. config.vlan_batadv
-	uci:section('network', 'interface', mesh, { proto = 'none', })
+	uci:section('network', 'interface', mesh,
+		{ proto = 'none', mtu = '1536',})
 	uci:delete('network', meshif)
 	uci:section('network', 'interface', meshif,
 	      {
 		ifname = meshifn,
 		proto = 'batadv',
-		mtu = '1528',
+		mtu = '1532',
 		mesh = 'bat0',
 	      }
 	)


### PR DESCRIPTION
for compatibility with existing freifunk leipzig nodes