### PR TITLE
Paket zum (de)aktivieren der einzelnen SSIDs

### DIFF
--- a/gluon/gluon-luci-wifi-config/Makefile
+++ b/gluon/gluon-luci-wifi-config/Makefile
@@ -1,0 +1,32 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-luci-wifi-config
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-luci-wifi-config
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  DEPENDS:=+gluon-luci-admin
+  TITLE:=UI for switching wifi on/off
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-luci-wifi-config/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-luci-wifi-config))

--- a/gluon/gluon-luci-wifi-config/files/usr/lib/lua/luci/controller/admin/wifi-config.lua
+++ b/gluon/gluon-luci-wifi-config/files/usr/lib/lua/luci/controller/admin/wifi-config.lua
@@ -1,0 +1,5 @@
+module("luci.controller.admin.wifi-config", package.seeall)
+
+function index()
+	entry({"admin", "wifi-config"}, cbi("admin/wifi-config"), "WLAN-Config", 20)
+end

--- a/gluon/gluon-luci-wifi-config/files/usr/lib/lua/luci/model/cbi/admin/wifi-config.lua
+++ b/gluon/gluon-luci-wifi-config/files/usr/lib/lua/luci/model/cbi/admin/wifi-config.lua
@@ -1,0 +1,90 @@
+local f, s, o
+local uci = luci.model.uci.cursor()
+local config = 'wireless'
+ 
+--set the heading, button and stuff 
+f = SimpleForm("wifi", "WLAN-Config")
+f.reset = false
+f.template = "admin/expertmode"
+f.submit = "Speichern"
+
+-- text, which describes what the package does to the user
+s = f:section(SimpleSection, nil, [[
+Viele Freifunk-Communitys betreiben ein sogenanntes Dachnetz. Das bedeutet, dass
+manche Router sich über große Strecken miteinander verbinden, um viele kleine
+Mesh-Netze miteinander zu verbinden. Um diese weiten Verbindungen effektiver zu
+gestalten hast du hier die Möglichkeit die SSID, mit der sich die Clients verbinden,
+zu deaktivieren.
+]])
+ 
+ 
+local radios = {}
+
+-- look for wifi interfaces and add them to the array
+uci:foreach('wireless', 'wifi-device',
+function(s)
+	table.insert(radios, s['.name'])
+end
+)
+
+--add a client and mesh checkbox  for each interface
+for index, radio in ipairs(radios) do
+ 	--get the hwmode to seperate 2.4GHz and 5Ghz radios
+	local hwmode = uci:get('wireless', radio, 'hwmode')
+	
+	if hwmode == '11g' or hwmode == '11ng' then --if 2.4GHz
+	 	--box for the clientnet
+		o = s:option(Flag, 'clientbox' .. index, "2,4GHz Client Netz aktivieren")
+		o.default = (uci:get_bool(config, 'client_' .. radio, "disabled")) and o.disabled or o.enabled
+		o.rmempty = false
+		--box for the meshnet 
+		o = s:option(Flag, 'meshbox' .. index, "2,4GHz Mesh Netz aktivieren")
+		o.default = (uci:get_bool(config, 'client_' .. radio, "disabled")) and o.disabled or o.enabled
+		o.rmempty = false
+	 
+	elseif hwmode == '11a' or hwmode == '11na' then --if 5GHz
+		--box for the clientnet
+		o = s:option(Flag, 'clientbox' .. index, "5GHz Client Netz aktivieren")
+		o.default = (uci:get_bool(config, 'client_' .. radio, "disabled")) and o.disabled or o.enabled
+		o.rmempty = false
+		--box for the meshnet
+		o = s:option(Flag, 'meshbox' .. index, "5GHz Mesh Netz aktivieren")
+		o.default = (uci:get_bool(config, 'client_' .. radio, "disabled")) and o.disabled or o.enabled
+		o.rmempty = false
+	 
+	end
+end
+ 
+--if the save-button is pushed
+function f.handle(self, state, data)
+	if state == FORM_VALID then
+	 
+		for index, radio in ipairs(radios) do
+
+			local clientstate, meshstate
+			-- get the data from the boxes and invert it
+			if data["clientbox"..index] == '0' then
+				clientenabled = 'true'
+			else
+				clientenabled = 'false'
+			end
+			-- write the data to the config file
+			uci:set(config, 'client_' .. radio, "disabled", clientenabled)
+
+			
+			if data["meshbox"..index] == '0' then                                                                      
+			    meshenabled = 'true'                                                                    
+			else                                                                                          
+			    meshenabled = 'false'                                                                   
+			end 
+						
+			uci:set(config, 'mesh_' .. radio, "disabled", meshenabled)
+
+		end
+
+	uci:save(config)
+	uci:commit(config)
+	end
+end
+ 
+return f

--- a/gluon/gluon-mesh-batman-adv-core/check_site.lua
+++ b/gluon/gluon-mesh-batman-adv-core/check_site.lua
@@ -7,6 +7,8 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
    need_string(config .. '.mesh_ssid')
    need_string_match(config .. '.mesh_bssid', '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$')
    need_number(config .. '.mesh_mcast_rate')
+   need_boolean(config .. '.ssid_disabled')
+   need_boolean(config .. '.mesh_disabled')
 end
 
 need_boolean('mesh_on_wan', false)

--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/mesh-batman-adv-core/invariant/020-wireless
@@ -22,6 +22,7 @@ local function configure_radio(radio, index, config)
 		mode = 'ap',
 		ssid = config.ssid,
 		macaddr = util.generate_mac(2, index),
+		disabled = config.ssid_disabled,
 	      }
   )
 
@@ -45,6 +46,7 @@ local function configure_radio(radio, index, config)
 		bssid = config.mesh_bssid,
 		macaddr = util.generate_mac(3, index),
 		mcast_rate = config.mesh_mcast_rate,
+		disabled = config.mesh_disabled,
 	      }
   )
 end


### PR DESCRIPTION
Viele Freifunk-Communitys nutzen Router an hohen Punkten für eine Funk-Backbone.
Allerdings empfangen die normalen Nutzer die Client-SSID sehr stark auf ihren Geräten, allerdings können sie nicht antworten, da sie selbst zu wenig Sendeleistung haben. Andere Communitys haben z.b. eine CPE210 und eine WR841nd direkt nebeneinander hängen, die über kabel meshen.
In solchen Fälle kann man sehr viel Airtime sparen und Durchsatz gewinnen, wenn man die Möglichkeit hat die einzelnen SSIDs an oder aus zu schalten.

Dieser Pull Request enthält einmal das Paket "gluon-luci-wifi-config" mit dem man im Configmode die einzelnen SSIDs (de)aktivieren kann und eine Erweiterung, die es erlaubt bestimmte SSIDs bereits beim kompilieren durch einen Eintrag in der site.conf zu (de)aktivieren. Dieses erfolgt durch folgende Einträge mit einem Boolean:
ssid_disabled = 'true'
mesh_disabled = 'false'

Das Configmode Paket sieht bei einem Singleband Router wie folgt aus, bei einem Dualband Router werden entsprechend weitere Checkboxen hinzugefügt.

![](http://labor19.net/freifunk/wifi-config.png)

Nach meinen Tests gibt es keine Probleme, auch lässt sich das Paket und die "site.conf"-Option kompilieren.