### PR TITLE
gluon-setup-mode: allow skipping on first boot

### DIFF
--- a/gluon/gluon-setup-mode/Makefile
+++ b/gluon/gluon-setup-mode/Makefile
@@ -35,4 +35,9 @@ define Package/gluon-setup-mode/install
 	$(CP) ./files/* $(1)/
 endef
 
+define Package/gluon-setup-mode/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
 $(eval $(call BuildPackage,gluon-setup-mode))

--- a/gluon/gluon-setup-mode/check_site.lua
+++ b/gluon/gluon-setup-mode/check_site.lua
@@ -1,0 +1,2 @@
+need_boolean('setup_mode.skip', false)
+

--- a/gluon/gluon-setup-mode/files/lib/gluon/upgrade/setup-mode/invariant/005-setup-mode
+++ b/gluon/gluon-setup-mode/files/lib/gluon/upgrade/setup-mode/invariant/005-setup-mode
@@ -1,0 +1,16 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local uci = require 'luci.model.uci'
+
+local c = uci.cursor()
+
+if site.setup_mode
+   and site.setup_mode.skip
+   and not c:get_first('gluon-setup-mode', 'setup_mode', 'configured', false) then
+     local name = c:get_first("gluon-setup-mode", "setup_mode")
+     c:set("gluon-setup-mode", name, "configured", 1)
+     c:save('gluon-setup-mode')
+     c:commit('gluon-setup-mode')
+end
+


### PR DESCRIPTION
By setting `setup_mode.skip` to `true` in site.conf the device will skip
setup mode on first boot.

fixes https://github.com/freifunk-gluon/gluon/issues/261