### PR TITLE
gluon-announce: add script to announce site_code

### DIFF
--- a/gluon/gluon-announce/files/lib/gluon/announce/nodeinfo.d/system/site_code
+++ b/gluon/gluon-announce/files/lib/gluon/announce/nodeinfo.d/system/site_code
@@ -1,0 +1,3 @@
+local site = require 'gluon.site_config'
+
+return site.site_code


### PR DESCRIPTION
Announcing the site_code inside the mesh would help a lot to distinguish different software builds (different communities sharing one mesh or the same gateways) in backend.