### PR TITLE
mesh-ba-core: remove dead code

### DIFF
--- a/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
+++ b/gluon/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
@@ -88,9 +88,9 @@ uci:foreach('wireless', 'wifi-device',
 for index, radio in ipairs(radios) do
 	local hwmode = uci:get('wireless', radio, 'hwmode')
 
-	if hwmode == '11g' or hwmode == '11ng' then
+	if hwmode == '11g' then
 	  configure_radio(radio, index, site.wifi24)
-	elseif hwmode == '11a' or hwmode == '11na' then
+	elseif hwmode == '11a' then
 	  configure_radio(radio, index, site.wifi5)
 	end
 end


### PR DESCRIPTION
hwmodes 11ng and 11na are invalid values:

http://wiki.openwrt.org/doc/uci/wireless