### PR TITLE
ebtables-filter-mcast: drop ARPs to/from 0.0.0.0

### DIFF
--- a/gluon/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-arp
+++ b/gluon/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-arp
@@ -1,1 +1,3 @@
+rule 'MULTICAST_OUT -p ARP --arp-opcode Reply --arp-ip-src 0.0.0.0 -j DROP'
+rule 'MULTICAST_OUT -p ARP --arp-opcode Request --arp-ip-dst 0.0.0.0 -j DROP'
 rule 'MULTICAST_OUT -p ARP -j RETURN'


### PR DESCRIPTION
Fixes https://github.com/freifunk-gluon/gluon/issues/311