### PR TITLE
fix IPv4 next node issue

### DIFF
--- a/gluon/gluon-next-node/files/lib/gluon/ebtables/250-next-node
+++ b/gluon/gluon-next-node/files/lib/gluon/ebtables/250-next-node
@@ -1,6 +1,9 @@
 local site = require 'gluon.site_config'
 local next_node = site.next_node
 
+rule('FORWARD --logical-in br-client -p ARP --arp-ip-src ' .. next_node.ip4 .. ' -j DROP')
+rule('FORWARD --logical-in br-client -p ARP --arp-ip-dst ' .. next_node.ip4 .. ' -j DROP')
+
 rule('FORWARD --logical-out br-client -o bat0 -d ' .. next_node.mac .. ' -j DROP')
 rule('OUTPUT --logical-out br-client -o bat0 -d ' .. next_node.mac .. ' -j DROP')
 rule('FORWARD --logical-out br-client -o bat0 -s ' .. next_node.mac .. ' -j DROP')

--- a/gluon/gluon-next-node/files/lib/gluon/upgrade/400-next-node
+++ b/gluon/gluon-next-node/files/lib/gluon/upgrade/400-next-node
@@ -17,25 +17,15 @@ c:section('network', 'device', 'local_node_dev',
 	  }
 )
 
+local prefix4 = ip.IPv4(site.prefix4)
 c:delete('network', 'local_node')
 c:section('network', 'interface', 'local_node',
 	  {
 		  ifname = 'local-node',
 		  proto = 'static',
 		  ipaddr = site.next_node.ip4,
-		  netmask = '255.255.255.255',
-		  ip6addr = site.next_node.ip6 .. '/128',
-	  }
-)
-
-local prefix4 = ip.IPv4(site.prefix4)
-c:delete('network', 'local_node_route4')
-c:section('network', 'route', 'local_node_route4',
-	  {
-		  interface = 'client',
-		  target = prefix4:network():string(),
 		  netmask = prefix4:mask():string(),
-		  gateway = '0.0.0.0',
+		  ip6addr = site.next_node.ip6 .. '/128',
 	  }
 )
 


### PR DESCRIPTION
Beim Freifunk Hackathon in Arnsberg ist aufgefallen dass die Next Node Webseite teilweise über IPv4 nicht zuverlässig zu erreichen ist.

Ursache dafür ist, dass die ARP Anfragen für die Next Node IP auch aus dem Mesh beantwortet werden und der Client somit eine falsche MAC lernt.

```
next node ip4 = '10.15.244.244'
next node mac = '50:51:52:53:54:55'

358  25.521954 IntelCor_d2:e4:98 -> Broadcast    ARP 42 Who has 10.15.244.244?  Tell 10.15.8.55
359  25.524964 Ubiquiti_0a:2e:f4 -> IntelCor_d2:e4:98 ARP 42 10.15.244.244 is at 68:72:51:0a:2e:f4
360  25.525014 50:51:52:53:54:55 -> IntelCor_d2:e4:98 ARP 42 10.15.244.244 is at 50:51:52:53:54:55
1819 118.212649 Tp-LinkT_f4:d6:f0 -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
5132 268.240415 Tp-LinkT_89:1e:ca -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
9694 459.774015 Tp-LinkT_7e:87:1c -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
9825 469.705415 Tp-LinkT_71:54:2e -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
11442 572.640722 Tp-LinkT_d0:51:36 -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
11930 596.230597 Tp-LinkT_f3:21:a0 -> Broadcast    ARP 42 Who has 10.15.254.250?  Tell 10.15.244.244 (duplicate use of 10.15.244.244 detected!)
```

Dieser Pull Request filtert die falschen ARP Pakete und behebt durch die geänderten Routen auch die Entstehung solcher Pakete.