### PR TITLE
Allow empty hostname prefix

### DIFF
--- a/gluon/gluon-core/check_site.lua
+++ b/gluon/gluon-core/check_site.lua
@@ -1,7 +1,7 @@
 need_string 'site_code'
 need_string 'site_name'
 
-need_string 'hostname_prefix'
+need_string('hostname_prefix', false)
 need_string 'timezone'
 
 need_string_array('ntp_servers', false)

--- a/gluon/gluon-core/files/lib/gluon/upgrade/030-system
+++ b/gluon/gluon-core/files/lib/gluon/upgrade/030-system
@@ -10,7 +10,7 @@ if not sysconfig.gluon_version then
 
   local system = uci:get_first('system', 'system')
 
-  uci:set('system', system, 'hostname', site.hostname_prefix .. '-' .. util.node_id())
+  uci:set('system', system, 'hostname', (site.hostname_prefix or '') .. util.node_id())
   uci:set('system', system, 'timezone', site.timezone)
 
   uci:save('system')


### PR DESCRIPTION
In Bremen it has been noted that a prefix may lead people to believe it
has to stay there and thus naming their nodes "ffhb-*", which is not
what the community wants (see FreifunkBremen/gluon-site-ffhb#1).

However, an empty prefix lead to the connecting hyphen still being
inserted. This commit thus only inserts this hyphen if the hostname
prefix is non-empty.