### PR TITLE
gluon-config-mode-mesh-vpn: Remove trailing newline from pubkey variable in 0100-mesh-vpn.lua

### DIFF
--- a/gluon/gluon-config-mode-mesh-vpn/files/lib/gluon/config-mode/reboot/0100-mesh-vpn.lua
+++ b/gluon/gluon-config-mode-mesh-vpn/files/lib/gluon/config-mode/reboot/0100-mesh-vpn.lua
@@ -9,7 +9,7 @@ else
   local site = require 'gluon.site_config'
   local sysconfig = require 'gluon.sysconfig'
 
-  local pubkey = util.exec("/etc/init.d/fastd show_key " .. "mesh_vpn")
+  local pubkey = util.trim(util.exec("/etc/init.d/fastd show_key " .. "mesh_vpn"))
   local hostname = uci:get_first("system", "system", "hostname")
 
   local msg = [[<p>]] .. i18n.translate('gluon-config-mode:pubkey') .. [[</p>


### PR DESCRIPTION
Fix: Removes the trailing newline from the return string of the "fastd show_key ..." command.