### PR TITLE
Reveal unintentionally hidden text

### DIFF
--- a/net/respondd/README.md
+++ b/net/respondd/README.md
@@ -1,5 +1,5 @@
 respondd providers are C modules (shared objects). These modules should include
-<json-c/json.h> and <respondd.h>, the latter of which provides the following definitions:
+\<json-c/json.h> and \<respondd.h>, the latter of which provides the following definitions:
 
         typedef struct json_object * (*respondd_provider)(void);
 


### PR DESCRIPTION
See [rich diff](https://github.com/freifunk-gluon/packages/compare/master...Philzen:patch-1?name=patch-1&short_path=ea39d6a#diff-ea39d6a3dd50562eaa0ac425cb130c22)...

Anything formatted like a tag obviously won't be displayed in the Markdown render, thus escaping the two \<include> hints ;)