### PR TITLE
force autoupdate to ignore release by setting /lib/gluon/release to 0

### DIFF
--- a/admin/autoupdater/files/usr/sbin/autoupdater
+++ b/admin/autoupdater/files/usr/sbin/autoupdater
@@ -30,6 +30,8 @@ version_file:close()
 -- If force is true the updater will perform an upgrade regardless of
 -- the priority and even when it is disabled in uci
 local force = false
+-- if you want to skip release test also
+local superforce = false
 
 -- If fallback is true the updater will perform an update only if the
 -- timespan given by the priority and another 24h have passed
@@ -40,6 +42,9 @@ local function parse_args()
   local i = 1
   while arg[i] do
     if arg[i] == '-f' then
+      force = true
+    elseif arg[i] == '-F' then
+      superforce = true
       force = true
     elseif arg[i] == '--fallback' then
       fallback = true
@@ -252,8 +257,10 @@ local function autoupdate(mirror)
   end
 
   if not autoupdater_version.newer_than(manifest.version, old_version) then
+    if superforce ~= true then
+      return true
+    end
     io.stderr:write('No new firmware available.\n')
-    return true
   end
 
   io.stderr:write('New version available.\n')


### PR DESCRIPTION
so autoupdater will try to do a update - even when it fails in the first place (so next time)
this is nice if wrong release strings are there (for mistakenly have v2106.1.2 for example), or if you do minor changes without having new release string.
(you have to do the autoupdater in this case per hand , but you can profit from the structures .. so you dont have to cre about model and all the stuff)

sideeffect : if wanted you can call autoupdater everytime like this (-F) and it will do everytime a update !!
