### PR TITLE
Create a lock-file while running autoupdate-process

### DIFF
--- a/admin/autoupdater/files/usr/lib/autoupdater/upgrade.d/00lockfile
+++ b/admin/autoupdater/files/usr/lib/autoupdater/upgrade.d/00lockfile
@@ -1,0 +1,8 @@
+# Create a lockfile for 3rd-party scripts which can be checked easily to ensure that
+# no reboot will be initiated while autoupdater is running
+
+lockfile='/tmp/autoupdate.lock'
+
+touch $lockfile || logger "gluon-autoupdater: lockfile could not be written"
+
+exit 0


### PR DESCRIPTION
There are many scripts out there, which detect some error-states of the freifunk-router, which actually conflicts with the autoupdate-process. So some might detect issues while updating and would init a reboot while sysupgrade is still writing the image.

To ensure such race conditions does not occur this patch provides a simple lock-file which can be checked by 3rd-party software to ensure autoupdate is not running before they init a reboot.
