### PR TITLE
respondd: delay replies to multicast packages to avoid flooding the server

### DIFF
--- a/net/respondd/src/respondd.c
+++ b/net/respondd/src/respondd.c
@@ -369,7 +369,7 @@ static void serve(int sock) {
 		break;
 	}
 	// Now "cmsg != NULL" tests whether we found the destination address at all.
-	const bool is_multicast = (cmsg != NULL) && destaddr.s6_addr[0] == 0xFF;
+	const bool is_multicast = (cmsg != NULL) && IN6_IS_ADDR_MULTICAST(&destaddr);
 
 	const char *str = json_object_to_json_string_ext(result, JSON_C_TO_STRING_PLAIN);
 


### PR DESCRIPTION
Right now, when a multicast respondd request it sent to the network, all nodes respond at once. This is (in a network with 400 nodes) almost one megabyte of data arriving within a very short timeframe. As a result, the UDP receive buffers of the server fill up and packets are dropped.

This patch adds a random delay of up to one second before replying to a multicast packet. Unicast requests are not affected. To achieve this, I had to use `recvmsg` instead of `recvfrom`, which complicated things "a little". I am not very familiar with `recvmsg` or C socket programming in general, so maybe someone who knows more should check this. ;-) I tested this in a KVM machine where everything worked as expected.
