### PR TITLE
respondd: Read list of multicast interfaces from file, add initscript

### DIFF
--- a/net/respondd/Makefile
+++ b/net/respondd/Makefile
@@ -25,6 +25,7 @@ define Build/Prepare
 endef
 
 define Package/respondd/install
+	$(CP) ./files/* $(1)/
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/respondd $(1)/usr/bin/
 endef

--- a/net/respondd/files/etc/config/respondd
+++ b/net/respondd/files/etc/config/respondd
@@ -1,0 +1,5 @@
+config respondd
+	option port '1001'
+	option mcast_group 'ff02::2:1001'
+	option iface_list_file '/etc/respondd.ifaces'
+	option data_dir '/lib/respondd'

--- a/net/respondd/files/etc/init.d/respondd
+++ b/net/respondd/files/etc/init.d/respondd
@@ -1,0 +1,45 @@
+#!/bin/sh /etc/rc.common
+
+USE_PROCD=1
+START=50
+
+DAEMON=/usr/bin/respondd
+PIDFILE=/var/run/respondd.pid
+
+validate_respondd_section() {
+	uci_validate_section respondd respondd "${1}" \
+		'port:uinteger' \
+		'mcast_group:string' \
+		'iface_list_file:file' \
+		'data_dir:directory'
+}
+
+start_service() {
+	config_load respondd
+	config_foreach start_respondd respondd
+}
+
+start_respondd() {
+	local port mcast_group iface_list_file data_dir
+	validate_respondd_section "$1"
+
+	procd_open_instance
+	procd_set_param command $DAEMON \
+		${mcast_group:+-g "$mcast_group"} \
+		${iface_list_file:+-c "$iface_list_file"} \
+		${port:+-p $port} \
+		${data_dir:+-d "$data_dir"}
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param pidfile $PIDFILE
+	procd_set_param stderr 1
+	procd_close_instance
+}
+
+reload_service() {
+	kill -HUP $(cat $PIDFILE)
+}
+
+service_triggers() {
+	procd_add_reload_trigger "respondd"
+	procd_add_validation "validate_respondd_section"
+}


### PR DESCRIPTION
We currently restart respondd regularly if something about the interfaces changes. This makes it possible to instead send a SIGHUP and respondd will reload the list of interfaces from a file.

Furthermore, if we ever want to upstream respondd (or make it usable outside Gluon), an initscript is more than helpful. Thus, I added one that uses UCI variables for all parameters and procd to log the stderr.
