### PR TITLE
x86: add geode platform

### DIFF
--- a/libs/libplatforminfo/Makefile
+++ b/libs/libplatforminfo/Makefile
@@ -16,7 +16,7 @@ define Package/libplatforminfo
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=Platform information library
-  DEPENDS:=@(TARGET_ar71xx_generic||TARGET_ar71xx_mikrotik||TARGET_ar71xx_nand||TARGET_mpc85xx_generic||TARGET_x86_generic||TARGET_x86_kvm_guest||TARGET_x86_64||TARGET_x86_xen_domu||TARGET_ramips_mt7621||TARGET_ramips_rt305x||TARGET_brcm2708_bcm2708||TARGET_brcm2708_bcm2709||TARGET_sunxi)
+  DEPENDS:=@(TARGET_ar71xx_generic||TARGET_ar71xx_mikrotik||TARGET_ar71xx_nand||TARGET_mpc85xx_generic||TARGET_x86_generic||TARGET_x86_geode||TARGET_x86_kvm_guest||TARGET_x86_64||TARGET_x86_xen_domu||TARGET_ramips_mt7621||TARGET_ramips_rt305x||TARGET_brcm2708_bcm2708||TARGET_brcm2708_bcm2709||TARGET_sunxi)
 endef
 
 CMAKE_OPTIONS += \

--- a/libs/libplatforminfo/src/targets/template/x86.c
+++ b/libs/libplatforminfo/src/targets/template/x86.c
@@ -95,6 +95,8 @@ const char * platforminfo_get_model(void) {
 const char * platforminfo_get_image_name(void) {
 #if defined(TARGET_x86_generic)
         return "x86-generic";
+#elif defined(TARGET_x86_geode)
+        return "x86-geode";
 #elif defined(TARGET_x86_kvm_guest)
         return "x86-kvm";
 #elif defined(TARGET_x86_xen_domu)

--- a/libs/libplatforminfo/src/targets/x86-geode.c
+++ b/libs/libplatforminfo/src/targets/x86-geode.c
@@ -1,0 +1,1 @@
+template/x86.c


### PR DESCRIPTION
We use some geode based boards as offloaders or for wireless controller based environments. The normal x86 images did not boot on these boards.
