### PR TITLE
respondd-module-airtime: Improve error handling

### DIFF
--- a/net/respondd-module-airtime/src/Makefile
+++ b/net/respondd-module-airtime/src/Makefile
@@ -9,7 +9,7 @@ all: respondd.so
 
 %.c: %.h
 
-respondd.so: airtime.c ifaces.c respondd.c
+respondd.so: netlink.c airtime.c ifaces.c respondd.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -fPIC -D_GNU_SOURCE -lnl-tiny -o $@ $^ $(LDLIBS)
 
 clean:

--- a/net/respondd-module-airtime/src/airtime.h
+++ b/net/respondd-module-airtime/src/airtime.h
@@ -2,14 +2,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <json-c/json.h>
 
-struct airtime_result {
-	uint64_t active_time;
-	uint64_t busy_time;
-	uint64_t rx_time;
-	uint64_t tx_time;
-	uint32_t frequency;
-	uint8_t  noise;
-};
-
-__attribute__((visibility("hidden"))) bool get_airtime(struct airtime_result *result, int ifx);
+__attribute__((visibility("hidden"))) bool get_airtime(struct json_object *result, int ifx);

--- a/net/respondd-module-airtime/src/ifaces.c
+++ b/net/respondd-module-airtime/src/ifaces.c
@@ -12,12 +12,17 @@ static int iface_dump_handler(struct nl_msg *msg, void *arg) {
 
 	nla_parse(tb, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
 
+	if (!tb[NL80211_ATTR_WIPHY] || !tb[NL80211_ATTR_IFINDEX])
+		goto skip;
+
 	wiphy = nla_get_u32(tb[NL80211_ATTR_WIPHY]);
 	for (last_next = arg; *last_next != NULL; last_next = &(*last_next)->next) {
 		if ((*last_next)->wiphy == wiphy)
 			goto skip;
 	}
 	*last_next = malloc(sizeof(**last_next));
+	if (!*last_next)
+		goto skip;
 	(*last_next)->next = NULL;
 	(*last_next)->ifx = nla_get_u32(tb[NL80211_ATTR_IFINDEX]);
 	(*last_next)->wiphy = wiphy;

--- a/net/respondd-module-airtime/src/netlink.c
+++ b/net/respondd-module-airtime/src/netlink.c
@@ -1,0 +1,43 @@
+#include <linux/nl80211.h>
+#include <netlink/genl/genl.h>
+#include <netlink/genl/ctrl.h>
+
+#include "netlink.h"
+
+bool nl_send_dump(nl_recvmsg_msg_cb_t cb, void *cb_arg, int cmd, uint32_t cmd_arg) {
+	bool ok = false;
+	int ctrl;
+	struct nl_sock *sk = NULL;
+	struct nl_msg *msg = NULL;
+
+
+#define CHECK(x) { if (!(x)) { fprintf(stderr, "%s: error on line %d\n", __FILE__, __LINE__); goto out; } }
+
+	CHECK(sk = nl_socket_alloc());
+	CHECK(genl_connect(sk) >= 0);
+
+	CHECK(ctrl = genl_ctrl_resolve(sk, NL80211_GENL_NAME));
+	CHECK(nl_socket_modify_cb(sk, NL_CB_VALID, NL_CB_CUSTOM, cb, cb_arg) == 0);
+	CHECK(msg = nlmsg_alloc());
+	CHECK(genlmsg_put(msg, 0, 0, ctrl, 0, NLM_F_DUMP, cmd, 0));
+
+	if (cmd_arg != 0)
+		NLA_PUT_U32(msg, NL80211_ATTR_IFINDEX, cmd_arg);
+
+	CHECK(nl_send_auto_complete(sk, msg) >= 0);
+	CHECK(nl_recvmsgs_default(sk) >= 0);
+
+#undef CHECK
+
+	ok = true;
+
+nla_put_failure:
+out:
+	if (msg)
+		nlmsg_free(msg);
+
+	if (sk)
+		nl_socket_free(sk);
+
+	return ok;
+}

--- a/net/respondd-module-airtime/src/netlink.h
+++ b/net/respondd-module-airtime/src/netlink.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <netlink/handlers.h>
+
+__attribute__((visibility("hidden"))) bool nl_send_dump(nl_recvmsg_msg_cb_t cb, void *cb_arg, int cmd, uint32_t cmd_arg);

--- a/net/respondd-module-airtime/src/respondd.c
+++ b/net/respondd-module-airtime/src/respondd.c
@@ -6,25 +6,7 @@
 #include "airtime.h"
 #include "ifaces.h"
 
-static void fill_airtime_json(struct airtime_result *air, struct json_object *wireless) {
-	struct json_object *obj;
-
-	obj = json_object_new_object();
-	if (!obj)
-		return;
-
-	json_object_object_add(obj, "frequency", json_object_new_int(air->frequency));
-	json_object_object_add(obj, "active",    json_object_new_int64(air->active_time));
-	json_object_object_add(obj, "busy",      json_object_new_int64(air->busy_time));
-	json_object_object_add(obj, "rx",        json_object_new_int64(air->rx_time));
-	json_object_object_add(obj, "tx",        json_object_new_int64(air->tx_time));
-	json_object_object_add(obj, "noise",     json_object_new_int(air->noise));
-
-	json_object_array_add(wireless, obj);
-}
-
 static struct json_object *respondd_provider_statistics(void) {
-	struct airtime_result airtime = {0};
 	struct json_object *result, *wireless;
 	struct iface_list *ifaces;
 
@@ -40,8 +22,7 @@ static struct json_object *respondd_provider_statistics(void) {
 
 	ifaces = get_ifaces();
 	while (ifaces != NULL) {
-		if (get_airtime(&airtime, ifaces->ifx))
-			fill_airtime_json(&airtime, wireless);
+		get_airtime(wireless, ifaces->ifx);
 
 		void *freeptr = ifaces;
 		ifaces = ifaces->next;


### PR DESCRIPTION
* Unify similar code for dumping netlink stuff
* Only add items to the object returned to respondd that are returned from netlink (this fixes #157)
* Add various checks for successful allocations (this also fixes #158)

Tradeoff: The clear line "JSON in respondd.c, netlink in airtime.c" had to be torn down in order to build the JSON directly while parsing the netlink response in airtime.c