### PR TITLE
net/l3roamd: add basic package

### DIFF
--- a/net/l3roamd/Makefile
+++ b/net/l3roamd/Makefile
@@ -1,0 +1,26 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=l3roamd
+PKG_SOURCE_DATE:=2017-02-21
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/freifunk-gluon/l3roamd.git
+PKG_SOURCE_VERSION:=749e8ef09e2687337df36538ee17107bfe61b09e
+
+CMAKE_OPTIONS += -DCMAKE_BUILD_TYPE:STRING=MINSIZEREL
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/l3roamd
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=The layer 3 roaming daemon
+  DEPENDS:=+libnl-tiny +kmod-tun +librt
+endef
+
+define Package/l3roamd/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/l3roamd $(1)/usr/sbin/
+endef
+
+$(eval $(call BuildPackage,l3roamd))


### PR DESCRIPTION
this adds a basic version of l3roamd being used in the current babel-PR.

Having this allows for builds of firmware with babel.