### PR TITLE
mmfd: bump version

### DIFF
--- a/net/mmfd/Makefile
+++ b/net/mmfd/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=mmfd
 PKG_SOURCE_DATE:=2017-07-09
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/freifunk-gluon/mmfd.git
-PKG_SOURCE_VERSION:=cdcbf4129241421579aff2b50b073ac832e2f060
+PKG_SOURCE_VERSION:=f160e334f1264cda027a12f650962235cde24168
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -13,7 +13,7 @@ define Package/mmfd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=mesh multicast forwarding daemon
-  DEPENDS:= +kmod-tun +babeld
+  DEPENDS:= +kmod-tun +babeld +libbabelhelper
 endef
 
 define Package/mmfd/install


### PR DESCRIPTION
this will allow using the latest mmfd optimisations:
* do not send the packet back to the originator
* flush neighbours when re-connecting to babel
* extend usage of libbabelhelper