### PR TITLE
autoupdater: Fix nullpointer dereference on invalid URL

### DIFF
--- a/admin/autoupdater/Makefile
+++ b/admin/autoupdater/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autoupdater
-PKG_VERSION:=3
+PKG_VERSION:=4
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -161,6 +161,9 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 	};
 
 	struct uclient *cl = uclient_new(url, NULL, &cb);
+	if (!cl)
+		goto err;
+
 	cl->priv = &d;
 	if (uclient_set_timeout(cl, TIMEOUT_MSEC))
 		goto err;
@@ -183,6 +186,8 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 	return d.err_code;
 
 err:
-	uclient_free(cl);
+	if (cl)
+		uclient_free(cl);
+
 	return UCLIENT_ERROR_CONNECT;
 }


### PR DESCRIPTION
Previously supplying an invalid url for download would result in
uclient_new returning NULL and crash the autoupdater as soon as
cl->priv is accessed.

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>