### PR TITLE
autoupdater: Fix various possible nullpointer dereferences

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -144,7 +144,8 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 
 	if (optind < argc) {
 		settings->n_mirrors = argc - optind;
-		settings->mirrors = malloc(settings->n_mirrors * sizeof(char *));
+		settings->mirrors = safe_malloc(settings->n_mirrors * sizeof(char *), "failed to allocate memory for mirror list");
+
 		for (int i = optind; i < argc; i++) {
 			settings->mirrors[i - optind] = argv[i];
 		}

--- a/admin/autoupdater/src/manifest.c
+++ b/admin/autoupdater/src/manifest.c
@@ -89,6 +89,11 @@ void parse_line(char *line, struct manifest *m, const char *branch, const char *
 		}
 		m->n_signatures++;
 		m->signatures = realloc(m->signatures, m->n_signatures * sizeof(ecdsa_signature_t *));
+		if (!m->signatures) {
+			fprintf(stderr, "autoupdater: error: failed to extend signature list\n");
+			abort();
+		}
+
 		m->signatures[m->n_signatures - 1] = sig;
 	} else if (strcmp(line, "---") == 0) {
 		m->sep_found = true;

--- a/admin/autoupdater/src/manifest.c
+++ b/admin/autoupdater/src/manifest.c
@@ -23,9 +23,9 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
 #include "hexutil.h"
 #include "manifest.h"
+#include "util.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -80,7 +80,8 @@ static bool parse_rfc3339(const char *input, time_t *date) {
 
 void parse_line(char *line, struct manifest *m, const char *branch, const char *image_name) {
 	if (m->sep_found) {
-		ecdsa_signature_t *sig = malloc(sizeof(ecdsa_signature_t));
+		ecdsa_signature_t *sig = safe_malloc(sizeof(ecdsa_signature_t), "failed to allocate memory for signature");
+
 		if (!parsehex(sig, line, sizeof(*sig))) {
 			free(sig);
 			fprintf(stderr, "autoupdater: warning: garbage in signature area: %s\n", line);

--- a/admin/autoupdater/src/settings.c
+++ b/admin/autoupdater/src/settings.c
@@ -110,6 +110,11 @@ static const char ** load_string_list(struct uci_context *ctx, struct uci_sectio
 
 void load_settings(struct settings *settings) {
 	struct uci_context *ctx = uci_alloc_context();
+	if (!ctx) {
+		fprintf(stderr, "autoupdater: error: failed to allocate uci context\n");
+		exit(1);
+	}
+
 	ctx->flags &= ~UCI_FLAG_STRICT;
 
 	struct uci_package *p;

--- a/admin/autoupdater/src/settings.c
+++ b/admin/autoupdater/src/settings.c
@@ -27,6 +27,7 @@
 
 #include "settings.h"
 #include "hexutil.h"
+#include "util.h"
 
 #include <uci.h>
 
@@ -97,7 +98,7 @@ static const char ** load_string_list(struct uci_context *ctx, struct uci_sectio
 		i++;
 
 	*len = i;
-	const char **ret = malloc(i * sizeof(char *));
+	const char **ret = safe_malloc(i * sizeof(char *), "failed to allocate string list");
 
 	i = 0;
 	uci_foreach_element(&o->v.list, e)
@@ -154,7 +155,7 @@ void load_settings(struct settings *settings) {
 		settings->mirrors = load_string_list(ctx, branch, "mirror", &settings->n_mirrors);
 
 	const char **pubkeys_str = load_string_list(ctx, branch, "pubkey", &settings->n_pubkeys);
-	settings->pubkeys = malloc(settings->n_pubkeys * sizeof(ecc_25519_work_t));
+	settings->pubkeys = safe_malloc(settings->n_pubkeys * sizeof(ecc_25519_work_t), "failed to allocate memory for public keys");
 	size_t ignored_keys = 0;
 	for (size_t i = 0; i < settings->n_pubkeys; i++) {
 		ecc_int256_t pubkey_packed;

--- a/admin/autoupdater/src/util.c
+++ b/admin/autoupdater/src/util.c
@@ -100,3 +100,15 @@ float get_uptime(void) {
 	fputs("autoupdater: error: unable to determine uptime\n", stderr);
 	exit(1);
 }
+
+void *safe_malloc(size_t size, char *errmsg) {
+	void *ret = malloc(size);
+
+	if (ret)
+		return ret;
+
+	if (errmsg)
+		fprintf(stderr, "autoupdater: error: %s\n", errmsg);
+
+	abort();
+}

--- a/admin/autoupdater/src/util.h
+++ b/admin/autoupdater/src/util.h
@@ -28,3 +28,4 @@
 void run_dir(const char *dir);
 void randomize(void);
 float get_uptime(void);
+void *safe_malloc(size_t size, char *errmsg);


### PR DESCRIPTION
The following commits fix some possible nullpointer dereferences due to failing dynamic memory allocations.

I've split the fixes into quite a few separate commits to make reviewing easier; just let me know in case you prefer fewer commits (1 per file or somehing)

Signed-off-by: Tobias Schramm tobleminer@gmail.com