### PR TITLE
autoupdater: allow skipping the versioncheck

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -101,7 +101,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		OPTION_HELP = 'h',
 		OPTION_NO_ACTION = 'n',
 		OPTION_FALLBACK = 256,
-		OPTION_NO_VERSIONCHECK = 255,
+		OPTION_NO_VERSIONCHECK = 257,
 	};
 
 	const struct option options[] = {

--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -86,6 +86,7 @@ static void usage(void) {
 		"                       really flash a new firmware if one is available.\n\n"
 		"  --fallback           Upgrade if and only if the upgrade timespan of the new\n"
 		"                       version has passed for at least 24 hours.\n\n"
+		"  --no-versioncheck    Skip version check and allow downgrades therefore.\n\n"
 		"  <mirror> ...         Override the mirror URLs given in the configuration. If\n"
 		"                       specified, these are not shuffled.\n\n",
 		stderr
@@ -100,6 +101,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		OPTION_HELP = 'h',
 		OPTION_NO_ACTION = 'n',
 		OPTION_FALLBACK = 256,
+		OPTION_NO_VERSIONCHECK = 255,
 	};
 
 	const struct option options[] = {
@@ -107,6 +109,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		{"force",     no_argument,       NULL, OPTION_FORCE},
 		{"fallback",  no_argument,       NULL, OPTION_FALLBACK},
 		{"no-action", no_argument,       NULL, OPTION_NO_ACTION},
+		{"no-versioncheck", no_argument, NULL, OPTION_NO_VERSIONCHECK},
 		{"help",      no_argument,       NULL, OPTION_HELP},
 	};
 
@@ -134,6 +137,10 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 
 		case OPTION_NO_ACTION:
 			settings->no_action = true;
+			break;
+
+		case OPTION_NO_VERSIONCHECK:
+			settings->no_versioncheck = true;
 			break;
 
 		default:
@@ -321,7 +328,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 	}
 
 	/* Check version and update probability */
-	if (!newer_than(m->version, s->old_version)) {
+	if (!newer_than(m->version, s->old_version) && !s->no_versioncheck) {
 		puts("No new firmware available.");
 		ret = true;
 		goto out;

--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -86,7 +86,7 @@ static void usage(void) {
 		"                       really flash a new firmware if one is available.\n\n"
 		"  --fallback           Upgrade if and only if the upgrade timespan of the new\n"
 		"                       version has passed for at least 24 hours.\n\n"
-		"  --force-version      Skip version check and allow downgrades therefore.\n\n"
+		"  --force-version      Skip version check to allow downgrades.\n\n"
 		"  <mirror> ...         Override the mirror URLs given in the configuration. If\n"
 		"                       specified, these are not shuffled.\n\n",
 		stderr

--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -86,7 +86,7 @@ static void usage(void) {
 		"                       really flash a new firmware if one is available.\n\n"
 		"  --fallback           Upgrade if and only if the upgrade timespan of the new\n"
 		"                       version has passed for at least 24 hours.\n\n"
-		"  --no-versioncheck    Skip version check and allow downgrades therefore.\n\n"
+		"  --force-version      Skip version check and allow downgrades therefore.\n\n"
 		"  <mirror> ...         Override the mirror URLs given in the configuration. If\n"
 		"                       specified, these are not shuffled.\n\n",
 		stderr
@@ -101,7 +101,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		OPTION_HELP = 'h',
 		OPTION_NO_ACTION = 'n',
 		OPTION_FALLBACK = 256,
-		OPTION_NO_VERSIONCHECK = 257,
+		OPTION_FORCE_VERSION = 257,
 	};
 
 	const struct option options[] = {
@@ -109,7 +109,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		{"force",     no_argument,       NULL, OPTION_FORCE},
 		{"fallback",  no_argument,       NULL, OPTION_FALLBACK},
 		{"no-action", no_argument,       NULL, OPTION_NO_ACTION},
-		{"no-versioncheck", no_argument, NULL, OPTION_NO_VERSIONCHECK},
+		{"force-version", no_argument, NULL, OPTION_FORCE_VERSION},
 		{"help",      no_argument,       NULL, OPTION_HELP},
 	};
 
@@ -139,8 +139,8 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 			settings->no_action = true;
 			break;
 
-		case OPTION_NO_VERSIONCHECK:
-			settings->no_versioncheck = true;
+		case OPTION_FORCE_VERSION:
+			settings->force_version = true;
 			break;
 
 		default:
@@ -328,7 +328,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 	}
 
 	/* Check version and update probability */
-	if (!newer_than(m->version, s->old_version) && !s->no_versioncheck) {
+	if (!newer_than(m->version, s->old_version) && !s->force_version) {
 		puts("No new firmware available.");
 		ret = true;
 		goto out;

--- a/admin/autoupdater/src/settings.h
+++ b/admin/autoupdater/src/settings.h
@@ -33,6 +33,7 @@ struct settings {
 	bool force;
 	bool fallback;
 	bool no_action;
+	bool no_versioncheck;
 	const char *branch;
 	unsigned long good_signatures;
 	char *old_version;

--- a/admin/autoupdater/src/settings.h
+++ b/admin/autoupdater/src/settings.h
@@ -33,7 +33,7 @@ struct settings {
 	bool force;
 	bool fallback;
 	bool no_action;
-	bool no_versioncheck;
+	bool force_version;
 	const char *branch;
 	unsigned long good_signatures;
 	char *old_version;


### PR DESCRIPTION
This commit introduces a new cli flag "--no-versioncheck"

TODO:
- [x] Compile check
- [x] Functional check