### PR TITLE
respondd-module-airtime: Fix reported noise result

### DIFF
--- a/net/respondd-module-airtime/Makefile
+++ b/net/respondd-module-airtime/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=respondd-module-airtime
 PKG_VERSION:=1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=BSD-2-Clause
 

--- a/net/respondd-module-airtime/src/airtime.c
+++ b/net/respondd-module-airtime/src/airtime.c
@@ -116,7 +116,10 @@ static int survey_airtime_handler(struct nl_msg *msg, void *arg) {
 				data_json = json_object_new_int(nla_get_u32(nla));
 				break;
 			case sizeof(uint8_t):
-				data_json = json_object_new_int(nla_get_u8(nla));
+				if (type == NL80211_SURVEY_INFO_NOISE)
+					data_json = json_object_new_int((int8_t)nla_get_u8(nla));
+				else
+					data_json = json_object_new_int(nla_get_u8(nla));
 				break;
 			default:
 				fprintf(stderr, "respondd-module-airtime: Unexpected NL attribute length: %d\n", nla_len(nla));


### PR DESCRIPTION
The noise value delivered by nl80211 is actually a signed int8. Thus it
must be interpreted as a signed value, too.

Signed-off-by: Tobias Schramm <tobleminer@gmail.com>