### PR TITLE
libplatforminfo: Add custom target

### DIFF
--- a/libs/libplatforminfo/Config.in
+++ b/libs/libplatforminfo/Config.in
@@ -1,0 +1,33 @@
+menu "Configuration"
+	depends on PACKAGE_libplatforminfo
+
+config LIBPLATFORMINFO_CUSTOM
+	bool "Use custom definitions"
+	default n
+	help
+		Use custom definitions to get the platform informations
+		from special files.
+
+if LIBPLATFORMINFO_CUSTOM
+
+config LIBPLATFORMINFO_BOARD_NAME
+	string "File to board name information"
+	default "/tmp/sysinfo/board_name"
+	help
+		File to board name information
+
+config LIBPLATFORMINFO_MODEL
+	string "File to model information"
+	default "/tmp/sysinfo/model"
+	help
+		File to model information
+
+config LIBPLATFORMINFO_IMAGE_NAME
+	string "File to image name information"
+	default ""
+	help
+		File to image name information
+
+endif # if LIBPLATFORMINFO_CUSTOM
+
+endmenu

--- a/libs/libplatforminfo/Makefile
+++ b/libs/libplatforminfo/Makefile
@@ -18,10 +18,21 @@ define Package/libplatforminfo
   TITLE:=Platform information library
 endef
 
+define Package/libplatforminfo/config
+	source "$(SOURCE)/Config.in"
+endef
+
 CMAKE_OPTIONS += \
 	-DTARGET:STRING="$(BOARD)" \
 	-DSUBTARGET:STRING="$(SUBTARGET)"
 
+ifeq ($(CONFIG_LIBPLATFORMINFO_CUSTOM),y)
+	CMAKE_OPTIONS += \
+		-DCUSTOM:BOOL=ON \
+		-DBOARD_NAME:STRING=$(CONFIG_LIBPLATFORMINFO_BOARD_NAME) \
+		-DMODEL:STRING=$(CONFIG_LIBPLATFORMINFO_MODEL) \
+		-DIMAGE_NAME:STRING=$(CONFIG_LIBPLATFORMINFO_IMAGE_NAME)
+endif
 
 define Package/libplatforminfo/install
 	$(INSTALL_DIR) $(1)/usr/lib

--- a/libs/libplatforminfo/src/CMakeLists.txt
+++ b/libs/libplatforminfo/src/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 set(TARGET "" CACHE STRING "OpenWrt target")
 set(SUBTARGET "" CACHE STRING "OpenWrt subtarget")
+set(CUSTOM OFF CACHE BOOL "Use custom file definitions")
 
 add_definitions(-DTARGET=${TARGET})
 
@@ -20,13 +21,20 @@ else(SUBTARGET)
   add_definitions(-DTARGET_${TARGET})
 endif(SUBTARGET)
 
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/targets/${FULL_TARGET}.c")
-  set(TARGET_SOURCE "targets/${FULL_TARGET}.c")
-elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/targets/${TARGET}.c")
-  set(TARGET_SOURCE "targets/${TARGET}.c")
-else()
-  set(TARGET_SOURCE "targets/default.c")
-endif()
+if(CUSTOM)
+  set(TARGET_SOURCE "targets/custom.c")
+  add_definitions(-DBOARD_NAME=\"${BOARD_NAME}\")
+  add_definitions(-DMODEL=\"${MODEL}\")
+  add_definitions(-DIMAGE_NAME=\"${IMAGE_NAME}\")
+else(CUSTOM)
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/targets/${FULL_TARGET}.c")
+    set(TARGET_SOURCE "targets/${FULL_TARGET}.c")
+  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/targets/${TARGET}.c")
+    set(TARGET_SOURCE "targets/${TARGET}.c")
+  else()
+    set(TARGET_SOURCE "targets/default.c")
+  endif()
+endif(CUSTOM)
 
 
 add_library(platforminfo SHARED

--- a/libs/libplatforminfo/src/targets/custom.c
+++ b/libs/libplatforminfo/src/targets/custom.c
@@ -1,0 +1,63 @@
+/*
+  Copyright (c) 2018, Florian Eckert <fe@dev.tdt.de>
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#include <libplatforminfo.h>
+#include "../common.h"
+
+
+static char * board_name = NULL;
+static char * model = NULL;
+static char * image_name = NULL;
+
+
+__attribute__((constructor)) static void init(void) {
+        board_name = read_line(BOARD_NAME);
+        model = read_line(MODEL);
+        image_name = read_line(IMAGE_NAME);
+}
+
+__attribute__((destructor)) static void deinit(void) {
+        free(board_name);
+        free(model);
+        free(image_name);
+
+        board_name = NULL;
+        model = NULL;
+        image_name = NULL;
+}
+
+
+const char * platforminfo_get_board_name(void) {
+        return board_name;
+}
+
+const char * platforminfo_get_model(void) {
+        return model;
+}
+
+const char * platforminfo_get_image_name(void) {
+        return image_name;
+}


### PR DESCRIPTION
With this target it is possible to define files in the openwrt **.config** which **libplatform** use to look for the information on the system.
I need this to use the **autoupdater** for a different application independently from freifunk if i have another image name convention.