### PR TITLE
autoupdater: add check for manifest info

### DIFF
--- a/admin/autoupdater/src/settings.h
+++ b/admin/autoupdater/src/settings.h
@@ -33,6 +33,7 @@ struct settings {
 	bool force;
 	bool fallback;
 	bool no_action;
+	bool check;
 	bool force_version;
 	const char *branch;
 	unsigned long good_signatures;


### PR DESCRIPTION
With the option -c (--check) we only download the manifest and verify
them. If manifest is valid and a new firmware is available then result
is printed to stdout.

VERSION=<image_version>
SIZE=<image_size>
