### PR TITLE
autoupdater: allow skipping the signatures check

### DIFF
--- a/admin/autoupdater/src/settings.h
+++ b/admin/autoupdater/src/settings.h
@@ -34,6 +34,7 @@ struct settings {
 	bool fallback;
 	bool no_action;
 	bool force_version;
+	bool force_signatures;
 	const char *branch;
 	unsigned long good_signatures;
 	char *old_version;


### PR DESCRIPTION
When deploying a new firmware a signer might want to test it on a variety of devices. At the moment this requires copying the image manually and flashing via sysupgrade or decreasing the required signatures in the autoupdater. This commit introduces a new cli flag "--force-signatures" which allows the user to skip the signature check.