### PR TITLE
overcome tunneldigger state reset error in case of broken broker

### DIFF
--- a/net/tunneldigger/patches/0001-tunneldigger-client-reset_broken_brokers.patch
+++ b/net/tunneldigger/patches/0001-tunneldigger-client-reset_broken_brokers.patch
@@ -25,15 +25,20 @@ index 16fdf3c..69ce54c 100644
 
      // Perform broker processing for 10 seconds or until all brokers are ready
      // (whichever is shorter); since all contexts are in standby mode, all
-@@ -1476,6 +1467,11 @@ int main(int argc, char **argv)
+@@ -1474,8 +1465,14 @@ int main(int argc, char **argv)
+
+     i = select_broker(brokers, broker_cnt, ready_cnt);
      if (i == -1) {
-       syslog(LOG_ERR, "No suitable brokers found. Retrying in 5 seconds");
+-      syslog(LOG_ERR, "No suitable brokers found. Retrying in 5 seconds");
++      syslog(LOG_ERR, "No suitable brokers found. Retrying in 5 seconds.");
        sleep(5);
 +      // Un-break all brokers.  There is no point in avoiding bad brokers if that means
 +      // we have no candidates left.
++      syslog(LOG_ERR, "Resetting status of brokers and starting from scratch.");
 +      for (i = 0; i < broker_cnt; i++) {
 +        brokers[i].broken = 0;
 +      }
        continue;
      }
+
 

--- a/net/tunneldigger/patches/0001-tunneldigger-client-reset_broken_brokers.patch
+++ b/net/tunneldigger/patches/0001-tunneldigger-client-reset_broken_brokers.patch
@@ -1,0 +1,39 @@
+diff --git a/client/l2tp_client.c b/client/l2tp_client.c
+index 16fdf3c..69ce54c 100644
+--- a/client/l2tp_client.c
++++ b/client/l2tp_client.c
+@@ -1431,10 +1431,6 @@ int main(int argc, char **argv)
+
+     // Reset availability information and standby setting.
+     for (i = 0; i < broker_cnt; i++) {
+-      // Re-enable all brokers if they are all broken
+-      if (working_brokers == 0) {
+-        brokers[i].broken = 0;
+-      }
+       if (brokers[i].broken) {
+         // Inhibit hostname resolution and connect process.
+         syslog(LOG_INFO, "Not trying %s:%s again as it broke last time we tried.",
+@@ -1442,11 +1438,6 @@ int main(int argc, char **argv)
+         brokers[i].ctx->state = STATE_FAILED;
+       }
+     }
+-    // Adapt working_brokers, needs updating if we re-enabled brokers
+-    if (working_brokers == 0) {
+-      syslog(LOG_INFO, "All brokers sent us an error, trying them all again.");
+-      working_brokers = broker_cnt;
+-    }
+
+     // Perform broker processing for 10 seconds or until all brokers are ready
+     // (whichever is shorter); since all contexts are in standby mode, all
+@@ -1476,6 +1467,11 @@ int main(int argc, char **argv)
+     if (i == -1) {
+       syslog(LOG_ERR, "No suitable brokers found. Retrying in 5 seconds");
+       sleep(5);
++      // Un-break all brokers.  There is no point in avoiding bad brokers if that means
++      // we have no candidates left.
++      for (i = 0; i < broker_cnt; i++) {
++        brokers[i].broken = 0;
++      }
+       continue;
+     }
+


### PR DESCRIPTION
Fix for https://github.com/wlanslovenija/tunneldigger/issues/87
credits: RalfJung

tested in 2018.2.1 with gluon provided tunneldigger -> tunneldigger-2017-12-13-d7db3500:

PKG_SOURCE_URL:=git://github.com/wlanslovenija/tunneldigger.git
PKG_SOURCE_DATE:=2017-12-13
PKG_SOURCE_VERSION:=d7db350011076d6a83855d412885a29a7d142b6e

as base.


`Thu Mar 28 01:05:24 2019 daemon.info td-client: Selected fgw02.freifunk-siegburg.de:20003 as the best broker.
Thu Mar 28 01:05:25 2019 daemon.warn td-client: Received error response from broker!
Thu Mar 28 01:05:25 2019 daemon.err td-client: Connection to fgw02.freifunk-siegburg.de lost.
Thu Mar 28 01:05:25 2019 daemon.info td-client: Performing broker selection...
Thu Mar 28 01:05:25 2019 daemon.info td-client: Not trying fgw02.freifunk-siegburg.de:20003 again as it broke last time we tried.
Thu Mar 28 01:05:36 2019 daemon.err td-client: No suitable brokers found. Retrying in 5 seconds.
Thu Mar 28 01:05:41 2019 daemon.err td-client: Resetting status of brokers and starting from scratch.
Thu Mar 28 01:05:41 2019 daemon.info td-client: Performing broker selection...
Thu Mar 28 01:05:42 2019 daemon.debug td-client: Broker usage of fgw02.freifunk-siegburg.de:20003: 1663
Thu Mar 28 01:05:52 2019 daemon.info td-client: Selected fgw02.freifunk-siegburg.de:20003 as the best broker.
Thu Mar 28 01:05:53 2019 daemon.info td-client: Tunnel successfully established.
Thu Mar 28 01:05:53 2019 daemon.notice netifd: Interface 'mesh_vpn' is enabled
Thu Mar 28 01:05:53 2019 daemon.notice netifd: Network device 'mesh-vpn' link is up
Thu Mar 28 01:05:53 2019 daemon.notice netifd: Interface 'mesh_vpn' has link connectivity
Thu Mar 28 01:05:53 2019 daemon.notice netifd: Interface 'mesh_vpn' is setting up now
Thu Mar 28 01:05:54 2019 daemon.notice netifd: Interface 'mesh_vpn' is now up
`