### PR TITLE
bump mmfd: remove babel dependency

### DIFF
--- a/net/mmfd/Makefile
+++ b/net/mmfd/Makefile
@@ -1,10 +1,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mmfd
-PKG_SOURCE_DATE:=2018-11-25
+PKG_SOURCE_DATE:=2019-07-07
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/freifunk-gluon/mmfd.git
-PKG_SOURCE_VERSION:=22996796e2f62972c2d70f94b0f656ec4968a55a
+PKG_SOURCE_VERSION:=2a9ff51260e81ae47caa3c7c3fcdbe84357bd561
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -13,7 +13,7 @@ define Package/mmfd
   SECTION:=net
   CATEGORY:=Network
   TITLE:=mesh multicast forwarding daemon
-  DEPENDS:= +kmod-tun +babeld +libbabelhelper
+  DEPENDS:= +kmod-tun
 endef
 
 define Package/mmfd/install


### PR DESCRIPTION
This bumps the version to an mmfd that will not turn cpu-bound in big networks with many changes on the babeld socket because the babeld socket is not used any more to determine neighbours.
A new mechanism is introduced to discover neighbours via multicast. To use it, all mesh interfaces must be specified.