### PR TITLE
autoupdater: Fixed segfault on wrong long option

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -112,6 +112,7 @@ static void parse_args(int argc, char *argv[], struct settings *settings) {
 		{"no-action", no_argument,       NULL, OPTION_NO_ACTION},
 		{"force-version", no_argument, NULL, OPTION_FORCE_VERSION},
 		{"help",      no_argument,       NULL, OPTION_HELP},
+		{0, 0, 0, 0}
 	};
 
 	while (true) {


### PR DESCRIPTION
If an autoupdater long option (prefixed with '--') are unknown then a segmentation fault occurs.
Example:
```
root@node:~# autoupdater --xyz
Segmentation fault
```
Fix:
autoupdater option struct termination by using ```{0, 0, 0, 0}```