### PR TITLE
respondd-module-airtime: add phy

### DIFF
--- a/net/respondd-module-airtime/README.md
+++ b/net/respondd-module-airtime/README.md
@@ -11,7 +11,8 @@ The format is the following:
         "busy": 46496566,
         "rx": 808415,
         "tx": 41711344,
-        "noise": 162
+        "noise": 162,
+        "phy": 1
       },
       {
         "frequency": 2437,
@@ -19,7 +20,8 @@ The format is the following:
         "busy": 205221222,
         "rx": 108121446,
         "tx": 85453679,
-        "noise": 161
+        "noise": 161,
+        "phy": 0
       }
     ]
   }
@@ -29,8 +31,12 @@ The format is the following:
 The numbers `active`, `busy`, `rx` and `tx` are times in milliseconds, where
 `busy`, `rx` and `tx` have to be interpreted by taking the quotient with
 `active`.
+`phy` is the index of the radio in the mac80211 subsystem.
 
 The motivation for having a list with the frequency as a value in the objects
 instead of having an object with the frequency as keys is that multiple wifi
 devices might be present, in which case the same frequency can appear multiple
 times (because the statistics are reported once for every phy).
+
+The field `phy` is added to distinguish multiple radios in the same band.
+It is not the key of mapped data due to backwards compatibility.

--- a/net/respondd-module-airtime/src/respondd.c
+++ b/net/respondd-module-airtime/src/respondd.c
@@ -7,7 +7,9 @@
 #include "ifaces.h"
 
 static struct json_object *respondd_provider_statistics(void) {
-	struct json_object *result, *wireless;
+	bool ok;
+	int newest_element_index;
+	struct json_object *last, *result, *wireless;
 	struct iface_list *ifaces;
 
 	result = json_object_new_object();
@@ -22,8 +24,12 @@ static struct json_object *respondd_provider_statistics(void) {
 
 	ifaces = get_ifaces();
 	while (ifaces != NULL) {
-		get_airtime(wireless, ifaces->ifx);
-
+		ok = get_airtime(wireless, ifaces->ifx);
+		if (ok) {
+			newest_element_index = json_object_array_length(wireless)-1;
+			last = json_object_array_get_idx(wireless, newest_element_index);
+			json_object_object_add(last, "phy", json_object_new_int(ifaces->wiphy));
+		}
 		void *freeptr = ifaces;
 		ifaces = ifaces->next;
 		free(freeptr);


### PR DESCRIPTION
This implements freifunk-gluon/gluon#2204.

The `wireless`-structure provided in statistics looks like this now:

```json
"wireless": [
    {
      "frequency": 5220,
      "active": 30461,
      "busy": 2057,
      "tx": 4,
      "idx": 1
    },
    {
      "frequency": 2412,
      "active": 31982,
      "busy": 7544,
      "tx": 156,
      "idx": 0
    }
  ],
```

There's a test router available at http://idx-test.n.ffh.zone .

*or as fallback* http://[2001:678:978:122:b64b:d6ff:fe22:4ebc]/cgi-bin/status