### PR TITLE
autoupdater: Add Gluon release to HTTP header

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -292,7 +292,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 
 	/* Download manifest */
 	ecdsa_sha256_init(&m->hash_ctx);
-	int err_code = get_url(manifest_url, recv_manifest_cb, &manifest_ctx, -1);
+	int err_code = get_url(manifest_url, recv_manifest_cb, &manifest_ctx, -1, s->old_version);
 	if (err_code != 0) {
 		fprintf(stderr, "autoupdater: warning: error downloading manifest: %s\n", uclient_get_errmsg(err_code));
 		goto out;
@@ -358,7 +358,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 		char image_url[strlen(mirror) + strlen(m->image_filename) + 2];
 		sprintf(image_url, "%s/%s", mirror, m->image_filename);
 		ecdsa_sha256_init(&image_ctx.hash_ctx);
-		int err_code = get_url(image_url, &recv_image_cb, &image_ctx, m->imagesize);
+		int err_code = get_url(image_url, &recv_image_cb, &image_ctx, m->imagesize, s->old_version);
 		puts("");
 		if (err_code != 0) {
 			fprintf(stderr, "autoupdater: warning: error downloading image: %s\n", uclient_get_errmsg(err_code));

--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -151,7 +151,7 @@ ssize_t uclient_read_account(struct uclient *cl, char *buf, int len) {
 }
 
 
-int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len) {
+int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len, const char *firmware_version) {
 	struct uclient_data d = { .custom = cb_data, .length = len };
 	struct uclient_cb cb = {
 		.header_done = header_done_cb,
@@ -175,6 +175,10 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 		goto err;
 	if (uclient_http_set_header(cl, "User-Agent", user_agent))
 		goto err;
+	if (firmware_version != NULL) {
+		if (uclient_http_set_header(cl, "X-Firmware-Version", firmware_version))
+			goto err;
+	}
 	if (uclient_request(cl))
 		goto err;
 	uloop_run();

--- a/admin/autoupdater/src/uclient.h
+++ b/admin/autoupdater/src/uclient.h
@@ -50,5 +50,5 @@ inline void * uclient_get_custom(struct uclient *cl) {
 
 ssize_t uclient_read_account(struct uclient *cl, char *buf, int len);
 
-int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len);
+int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len, const char *firmware_version);
 const char *uclient_get_errmsg(int code);


### PR DESCRIPTION
Send the access point's currently installed Gluon version in the HTTP header "X-GLUON-VERSION".

Resolves https://github.com/freifunk-gluon/gluon/issues/2232
