### PR TITLE
autoupdater: verify the image before upgrading

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -380,10 +380,12 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 
 	/* Test the image upgrade (issue #193) */
 	{
+		static const char *const exec_builtin = "exec ";
 		static const char *const test_option = " --test ";
 
-		char buf[strlen(sysupgrade_path) + strlen(test_option) + strlen(firmware_path) + 1];
-		strcpy(buf, sysupgrade_path);
+		char buf[strlen(exec_builtin) + strlen(sysupgrade_path) + strlen(test_option) + strlen(firmware_path) + 1];
+		strcpy(buf, exec_builtin);
+		strcat(buf, sysupgrade_path);
 		strcat(buf, test_option);
 		strcat(buf, firmware_path);
 

--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -378,6 +378,22 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 		}
 	}
 
+	/* Test the image upgrade (issue #193) */
+	{
+		static const char *const test_option = " --test ";
+
+		char buf[strlen(sysupgrade_path) + strlen(test_option) + strlen(firmware_path) + 1];
+		strcpy(buf, sysupgrade_path);
+		strcat(buf, test_option);
+		strcat(buf, firmware_path);
+
+		const int sysupgrade_ret = system(buf);
+		if (WEXITSTATUS(sysupgrade_ret) != 0 ) {
+			fprintf(stderr, "autoupdater: warning: sysupgrade --test failed with return code: %d\n", WEXITSTATUS(sysupgrade_ret));
+			goto fail_after_download;
+		}
+	}
+
 	clear_manifest(m);
 
 	/**** Call sysupgrade ************************************************/


### PR DESCRIPTION
Let sysupgrade run a --test upgrade to verify that the image is
compatible before attempting an upgrade.
This fixes an issue where a router can get stuck without network
connectivity when a a remote autoupgrade was triggered.

Fixes #193