### PR TITLE
wgpeerselector - keep datatype on ubus status

### DIFF
--- a/net/wgpeerselector/files/usr/bin/wgpeerselector
+++ b/net/wgpeerselector/files/usr/bin/wgpeerselector
@@ -323,9 +323,7 @@ function WGPeerSelector:status()
 				established = established
 			}
 		else
-			result.peers[peer.name] = false -- Fastd uses "null" here, but unfortunately
-			                                -- lua does not support setting table_keys to
-			                                -- nil.
+			result.peers[peer.name] = { }
 		end
 	end
 


### PR DESCRIPTION
an other datatype in same json structure makes problem an marshalling:
here an object and an boolean.

if there is no null posible, please add an empty object - this suggestes solution here.
or skip the else type