### PR TITLE
git:// links browned out since yesterday

### DIFF
--- a/net/tunneldigger/Makefile
+++ b/net/tunneldigger/Makefile
@@ -1,10 +1,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tunneldigger
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/wlanslovenija/tunneldigger.git
+PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger
 PKG_SOURCE_DATE:=2020-05-17
 PKG_SOURCE_VERSION:=8995046a2ba8f111391e01e6bb38a352c0cedaa1
 

--- a/net/tunneldigger/Makefile
+++ b/net/tunneldigger/Makefile
@@ -1,10 +1,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=tunneldigger
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger
+PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git
 PKG_SOURCE_DATE:=2020-05-17
 PKG_SOURCE_VERSION:=8995046a2ba8f111391e01e6bb38a352c0cedaa1
 


### PR DESCRIPTION
please backport to 2021.1.x too. 
see https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective
https://forum.freifunk.net/t/gluon-braucht-menschen-die-tunneldigger-aenderungen-testen/20674
https://github.com/eulenfunk/firmware/blob/0bd533077663c91aac4df232dad685c24763350d/patches/tunneldiggergit.patch