### PR TITLE
Fix PKG_SOURCE_URL of batman-adv-legacy and tunneldigger

### DIFF
--- a/net/batman-adv-legacy/Makefile
+++ b/net/batman-adv-legacy/Makefile
@@ -17,7 +17,7 @@ BATCTL_VERSION:=2013.4.0
 BATCTL_MD5SUM:=42e269cc710bbc9a8fd17628201d4258
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/freifunk-gluon/batman-adv-legacy.git
+PKG_SOURCE_URL:=https://github.com/freifunk-gluon/batman-adv-legacy.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=7b775e93b7d2d3f10b137e76090c82a06af65272
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz

--- a/net/tunneldigger/Makefile
+++ b/net/tunneldigger/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=tunneldigger
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=git://github.com/wlanslovenija/tunneldigger.git
+PKG_SOURCE_URL:=https://github.com/wlanslovenija/tunneldigger.git
 PKG_SOURCE_DATE:=2019-04-01
 PKG_SOURCE_VERSION:=7c467e68021526b8631e8a53a9022aa223b1991c
 


### PR DESCRIPTION
The build of Gluon is failing cause of an issue with the PKG_SOURCE_URL of some packages.

It is not possible to clone the source repositories using the git:// prefix, e.g. local tests:
```
$ git clone git://github.com/freifunk-gluon/batman-adv-legacy.git
Cloning into 'batman-adv-legacy'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Connection timed out
```

```
$ git clone git://github.com/wlanslovenija/tunneldigger.git
Cloning into 'tunneldigger'...
fatal: unable to connect to github.com:
github.com[0: 140.82.121.3]: errno=Connection timed out
```

Would be great to update the old package version of v2018.2.x to build the latest security fix of Gluon easily.