### PR TITLE
Autoupdater fixes (use-after-free, better signal handling)

### DIFF
--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -74,7 +74,6 @@ const char *uclient_get_errmsg(int code) {
 
 static void request_done(struct uclient *cl, int err_code) {
 	uclient_data(cl)->err_code = err_code;
-	uclient_disconnect(cl);
 	uloop_end();
 }
 
@@ -192,8 +191,10 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 	ret = d.err_code;
 
 err:
-	if (cl)
+	if (cl) {
+		uclient_disconnect(cl);
 		uclient_free(cl);
+	}
 
 	return ret;
 }

--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -159,6 +159,7 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 		.data_eof = eof_cb,
 		.error = request_done,
 	};
+	int ret = UCLIENT_ERROR_CONNECT;
 
 	struct uclient *cl = uclient_new(url, NULL, &cb);
 	if (!cl)
@@ -182,16 +183,17 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 	if (uclient_request(cl))
 		goto err;
 	uloop_run();
-	uclient_free(cl);
 
-	if (!d.err_code && d.length >= 0 && d.downloaded != d.length)
-		return UCLIENT_ERROR_SIZE_MISMATCH;
+	if (!d.err_code && d.length >= 0 && d.downloaded != d.length) {
+		ret = UCLIENT_ERROR_SIZE_MISMATCH;
+		goto err;
+	}
 
-	return d.err_code;
+	ret = d.err_code;
 
 err:
 	if (cl)
 		uclient_free(cl);
 
-	return UCLIENT_ERROR_CONNECT;
+	return ret;
 }

--- a/admin/autoupdater/src/uclient.h
+++ b/admin/autoupdater/src/uclient.h
@@ -52,3 +52,4 @@ ssize_t uclient_read_account(struct uclient *cl, char *buf, int len);
 
 int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len, const char *firmware_version);
 const char *uclient_get_errmsg(int code);
+int uclient_interrupted_signal(int code);


### PR DESCRIPTION
- Patch 1 is cleanup
- Patch 2 fixes a use-after-free (together with https://github.com/freifunk-gluon/gluon/pull/2796)
- Patch 3 improves signal handling, allowing to interrupt the autoupdater using Ctrl-C when it is safe to do so

Closes #261