### PR TITLE
autoupdater: delete /etc/opkg/keys on autoupdater upgrade

### DIFF
--- a/admin/autoupdater/files/usr/lib/autoupdater/upgrade.d/90delete_keys
+++ b/admin/autoupdater/files/usr/lib/autoupdater/upgrade.d/90delete_keys
@@ -1,0 +1,9 @@
+#!/usr/bin/lua
+local handle = io.popen("ls /etc/opkg/keys -1")
+local files = handle:read("*a")
+handle:close()
+
+for file in files:gmatch("[^\r\n]+") do
+  local filePath = "/etc/opkg/keys/" .. file
+  os.remove(filePath)
+end


### PR DESCRIPTION
- does trigger on autoupdate after checking that the image is correct and autoupgrade should be done

fixes https://github.com/freifunk-gluon/gluon/issues/2665
