### PR TITLE
simple-tc: fix kmod dependencies

### DIFF
--- a/net/simple-tc/Makefile
+++ b/net/simple-tc/Makefile
@@ -1,9 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=simple-tc
-PKG_VERSION:=2
-
-PKG_CONFIG_DEPENDS := CONFIG_KERNEL_NET_SCH_TBF CONFIG_KERNEL_NET_SCH_INGRESS CONFIG_KERNEL_NET_CLS_BASIC KERNEL_NET_ACT_POLICE
+PKG_VERSION:=3
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -11,7 +9,7 @@ define Package/simple-tc
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Simple bandwidth limiting
-  DEPENDS:=+!KERNEL_NET_SCH_TBF:kmod-sched-core +!KERNEL_NET_SCH_INGRESS:kmod-sched-core +!KERNEL_NET_CLS_BASIC:kmod-sched +!KERNEL_NET_ACT_POLICE:kmod-sched +libnl-tiny
+  DEPENDS:=+kmod-sched-core +kmod-sched-act-police +libnl-tiny
 endef
 
 TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny


### PR DESCRIPTION
simple-tc hasn't been working since OpenWrt 22.03, as act_police was moved to a separate package.

While we're at it, we can also clean up the other dependencies:

- Remove the obsolete conditional dependencies, these were for GLUON_SPECIALIZE_KERNEL
- cls_basic was moved to kmod-sched-core, so we don't need kmod-sched anymore

Fixes https://github.com/freifunk-gluon/gluon/issues/3017