### PR TITLE
ebtables-tiny: fix lockfile function

### DIFF
--- a/net/ebtables-tiny/src/libebtc.c
+++ b/net/ebtables-tiny/src/libebtc.c
@@ -127,6 +127,7 @@ void ebt_list_extensions()
 static int lock_file()
 {
 	int fd, try = 0;
+	int ret = 0;
 
 retry:
 	fd = open(LOCKFILE, O_CREAT, 00600);
@@ -136,7 +137,10 @@ retry:
 		try = 1;
 		goto retry;
 	}
-	return flock(fd, LOCK_EX);
+	ret = flock(fd, LOCK_EX | LOCK_NB);
+	if (ret)
+		close(fd);
+	return ret;
 }
 
 /* Get the table from the kernel or from a binary file */


### PR DESCRIPTION
flock without LOCK_NB never returns on a conflicting lock, so this function doesn't conform to its comment.

Also close the lock file on error, so we can keep retrying.