### PR TITLE
autoupdater: Backport X-FIRMWARE-VERSION header and image verification for 2021.1.x

### DIFF
--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -378,6 +378,24 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 		}
 	}
 
+	/* Test the image upgrade (issue #193) */
+	{
+		static const char *const exec_builtin = "exec ";
+		static const char *const test_option = " --test ";
+
+		char buf[strlen(exec_builtin) + strlen(sysupgrade_path) + strlen(test_option) + strlen(firmware_path) + 1];
+		strcpy(buf, exec_builtin);
+		strcat(buf, sysupgrade_path);
+		strcat(buf, test_option);
+		strcat(buf, firmware_path);
+
+		const int sysupgrade_ret = system(buf);
+		if (WEXITSTATUS(sysupgrade_ret) != 0 ) {
+			fprintf(stderr, "autoupdater: warning: sysupgrade --test failed with return code: %d\n", WEXITSTATUS(sysupgrade_ret));
+			goto fail_after_download;
+		}
+	}
+
 	clear_manifest(m);
 
 	/**** Call sysupgrade ************************************************/

--- a/admin/autoupdater/src/autoupdater.c
+++ b/admin/autoupdater/src/autoupdater.c
@@ -292,7 +292,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 
 	/* Download manifest */
 	ecdsa_sha256_init(&m->hash_ctx);
-	int err_code = get_url(manifest_url, recv_manifest_cb, &manifest_ctx, -1);
+	int err_code = get_url(manifest_url, recv_manifest_cb, &manifest_ctx, -1, s->old_version);
 	if (err_code != 0) {
 		fprintf(stderr, "autoupdater: warning: error downloading manifest: %s\n", uclient_get_errmsg(err_code));
 		goto out;
@@ -358,7 +358,7 @@ static bool autoupdate(const char *mirror, struct settings *s, int lock_fd) {
 		char image_url[strlen(mirror) + strlen(m->image_filename) + 2];
 		sprintf(image_url, "%s/%s", mirror, m->image_filename);
 		ecdsa_sha256_init(&image_ctx.hash_ctx);
-		int err_code = get_url(image_url, &recv_image_cb, &image_ctx, m->imagesize);
+		int err_code = get_url(image_url, &recv_image_cb, &image_ctx, m->imagesize, s->old_version);
 		puts("");
 		if (err_code != 0) {
 			fprintf(stderr, "autoupdater: warning: error downloading image: %s\n", uclient_get_errmsg(err_code));

--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -151,7 +151,7 @@ ssize_t uclient_read_account(struct uclient *cl, char *buf, int len) {
 }
 
 
-int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len) {
+int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len, const char *firmware_version) {
 	struct uclient_data d = { .custom = cb_data, .length = len };
 	struct uclient_cb cb = {
 		.header_done = header_done_cb,
@@ -175,6 +175,10 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 		goto err;
 	if (uclient_http_set_header(cl, "User-Agent", user_agent))
 		goto err;
+	if (firmware_version != NULL) {
+		if (uclient_http_set_header(cl, "X-Firmware-Version", firmware_version))
+			goto err;
+	}
 	if (uclient_request(cl))
 		goto err;
 	uloop_run();

--- a/admin/autoupdater/src/uclient.h
+++ b/admin/autoupdater/src/uclient.h
@@ -50,5 +50,5 @@ inline void * uclient_get_custom(struct uclient *cl) {
 
 ssize_t uclient_read_account(struct uclient *cl, char *buf, int len);
 
-int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len);
+int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data, ssize_t len, const char *firmware_version);
 const char *uclient_get_errmsg(int code);


### PR DESCRIPTION
backport of https://github.com/freifunk-gluon/packages/pull/247
related issues:
https://github.com/freifunk-gluon/packages/issues/193
https://github.com/freifunk-gluon/gluon/issues/2742
https://github.com/freifunk-gluon/gluon/issues/3181