### PR TITLE
ebtables-tiny: Fix lockfile function and reduce wait on lock

### DIFF
--- a/net/ebtables-tiny/src/libebtc.c
+++ b/net/ebtables-tiny/src/libebtc.c
@@ -127,6 +127,7 @@ void ebt_list_extensions()
 static int lock_file()
 {
 	int fd, try = 0;
+	int ret = 0;
 
 retry:
 	fd = open(LOCKFILE, O_CREAT, 00600);
@@ -136,7 +137,10 @@ retry:
 		try = 1;
 		goto retry;
 	}
-	return flock(fd, LOCK_EX);
+	ret = flock(fd, LOCK_EX | LOCK_NB);
+	if (ret)
+		close(fd);
+	return ret;
 }
 
 /* Get the table from the kernel or from a binary file */


### PR DESCRIPTION
During investigation of an issue with `ebtables` we discovered that the locking mechanism in `ebtables-tiny` did not work as expected. These commits should fix this issue.

These commits were part of the Freifunk Braunschweig *parker* -releases for about an year now. We did not discover any negative impact with these changes.