### PR TITLE
treewide: bump minimum CMake version

### DIFF
--- a/admin/autoupdater/src/CMakeLists.txt
+++ b/admin/autoupdater/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.20)
 
 project(AUTOUPDATER C)
 

--- a/libs/libplatforminfo/src/CMakeLists.txt
+++ b/libs/libplatforminfo/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 project(LIBPLATFORMINFO C)
 
 set(LIBDIR "lib${LIB_SUFFIX}")

--- a/libs/lua-jsonc/src/CMakeLists.txt
+++ b/libs/lua-jsonc/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(lua-jsonc C)
 

--- a/net/respondd/src/CMakeLists.txt
+++ b/net/respondd/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/net/sse-multiplex/src/CMakeLists.txt
+++ b/net/sse-multiplex/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 
 project(sse-multiplex C)
 


### PR DESCRIPTION
CMake 4 dropped support for CMakeList files with a minimum version less than 3.5.

Update all CMakeList files to target version 3.20 in order to build Gluon based on OpenWrt 24.10 and newer.