### PR TITLE
autoupdater: add ssl context if supported

### DIFF
--- a/admin/autoupdater/src/uclient.c
+++ b/admin/autoupdater/src/uclient.c
@@ -9,6 +9,8 @@
 
 #include <limits.h>
 #include <stdio.h>
+#include <string.h>
+#include <glob.h>
 
 
 #define TIMEOUT_MSEC 300000
@@ -43,6 +45,12 @@ const char *uclient_get_errmsg(int code) {
 		return "Connection failed";
 	case UCLIENT_ERROR_TIMEDOUT:
 		return "Connection timed out";
+	case UCLIENT_ERROR_SSL_INVALID_CERT:
+		return "Invalid SSL certificate";
+	case UCLIENT_ERROR_SSL_CN_MISMATCH:
+		return "SSL certificate CN mismatch";
+	case UCLIENT_ERROR_MISSING_SSL_CONTEXT:
+		return "Missing SSL context";
 	case UCLIENT_ERROR_REDIRECT_FAILED:
 		return "Failed to redirect";
 	case UCLIENT_ERROR_TOO_MANY_REDIRECTS:
@@ -151,10 +159,29 @@ int get_url(const char *url, void (*read_cb)(struct uclient *cl), void *cb_data,
 		.error = request_done,
 	};
 	int ret = UCLIENT_ERROR_CONNECT;
+	struct ustream_ssl_ctx *ssl_ctx = NULL;
+	const struct ustream_ssl_ops *ssl_ops = NULL;
 
 	struct uclient *cl = uclient_new(url, NULL, &cb);
 	if (!cl)
 		goto err;
+
+	ssl_ctx = uclient_new_ssl_context(&ssl_ops);
+	if (ssl_ctx) {
+		glob_t gl = {0};
+		unsigned int i;
+
+		if (glob("/etc/ssl/certs/*.crt", 0, NULL, &gl) == 0) {
+			for (i = 0; i < gl.gl_pathc; i++)
+				ssl_ops->context_add_ca_crt_file(ssl_ctx, gl.gl_pathv[i]);
+			globfree(&gl);
+		}
+
+		uclient_http_set_ssl_ctx(cl, ssl_ops, ssl_ctx, true);
+	} else if (!strncmp(url, "https://", strlen("https://"))) {
+		ret = UCLIENT_ERROR_MISSING_SSL_CONTEXT;
+		goto err;
+	}
 
 	cl->priv = &d;
 	if (uclient_set_timeout(cl, TIMEOUT_MSEC))
@@ -193,6 +220,8 @@ err:
 		uclient_disconnect(cl);
 		uclient_free(cl);
 	}
+	if (ssl_ctx)
+		ssl_ops->context_free(ssl_ctx);
 
 	return ret;
 }


### PR DESCRIPTION
This fixes the issue that the autoupdater does not support https urls.

Tested on AP-325 with `autoupdater -f https://....`